### PR TITLE
[cherry-pick] fix-3171

### DIFF
--- a/python/kserve/kserve/storage/storage.py
+++ b/python/kserve/kserve/storage/storage.py
@@ -166,6 +166,10 @@ class Storage(object):  # pylint: disable=too-few-public-methods
         endpoint_url = os.getenv("AWS_ENDPOINT_URL")
         if endpoint_url:
             kwargs.update({"endpoint_url": endpoint_url})
+        verify_ssl = os.getenv("S3_VERIFY_SSL")
+        if verify_ssl:
+            verify_ssl = verify_ssl != "0"
+            kwargs.update({"verify": verify_ssl})
         s3 = boto3.resource("s3", **kwargs)
         parsed = urlparse(uri, scheme='s3')
         bucket_name = parsed.netloc


### PR DESCRIPTION
This is a hotfix for https://github.com/kserve/kserve/pull/3172

upstream is not merged yet but Dell poc needs this change so a quick fix is needed.

Upstream PR has all test steps and I tested this with rhods 1.32 kserve.

~~~
Test instruction: https://github.com/opendatahub-io/caikit-tgis-serving/tree/main/demo/kserve/scripts

export TARGET_OPERATOR=rhods
export CHECK_UWM=false


# Update configmap to use the workaround image
  oc edit cm inferenceservice-config -n redhat-ods-applications
...
  storageInitializer: |-
    {
        "image" : "quay.io/jooholee/storage-initializer@sha256:6b6252e6a1df2a1140be4ab1f8b68b159e448aaf27b8f3212d19daeb44381af4",
...
# restart kserve controller
  oc delete pod -n redhat-ods-applications -l control-plane=kserve-controller-manager --force --grace-period=0
#add annotate to the storage-config secret
  oc annotate secret/storage-config  serving.kserve.io/s3-verifyssl="0" -n kserve-demo
# restart runtime pod
  oc delete pod $RUNTIME_POD --force --grace-period=0
~~~