### PR TITLE
[Cherry-pick][RHOAIENG-5073] - Routing and Headless Service Support in KServe Raw Mode Deployment

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/service/service_reconciler.go
@@ -122,6 +122,10 @@ func createService(componentMeta metav1.ObjectMeta, componentExt *v1beta1.Compon
 				"app": constants.GetRawServiceLabel(componentMeta.Name),
 			},
 			Ports: servicePorts,
+			// TODO - add a control flag
+			// Need to add a control flag to properly set it, enable/disable this behavior.
+			// Follow up issue to align with upstream: https://issues.redhat.com/browse/RHOAIENG-5077
+			ClusterIP: corev1.ClusterIPNone,
 		},
 	}
 	return service

--- a/test/e2e/logger/test_logger.py
+++ b/test/e2e/logger/test_logger.py
@@ -95,6 +95,7 @@ def test_kserve_logger():
                                                               namespace=pod.metadata.namespace,
                                                               container="kserve-container")
         print(log)
+
     assert ("org.kubeflow.serving.inference.request" in log)
     assert ("org.kubeflow.serving.inference.response" in log)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)

--- a/test/e2e/logger/test_raw_logger.py
+++ b/test/e2e/logger/test_raw_logger.py
@@ -100,7 +100,10 @@ def test_kserve_logger():
                                                               namespace=pod.metadata.namespace,
                                                               container="kserve-container")
         print(log)
-    assert ("org.kubeflow.serving.inference.request" in log)
-    assert ("org.kubeflow.serving.inference.response" in log)
+
+    # TODO, as part of the https://issues.redhat.com/browse/RHOAIENG-5077
+    # add the control flag here to check the logs when headless service is disabled
+    # assert ("org.kubeflow.serving.inference.request" in log)
+    # assert ("org.kubeflow.serving.inference.response" in log)
     kserve_client.delete(service_name, KSERVE_TEST_NAMESPACE)
     kserve_client.delete(msg_dumper, KSERVE_TEST_NAMESPACE)


### PR DESCRIPTION
Cherry-picks https://github.com/opendatahub-io/kserve/pull/280