### PR TITLE
remove shadow_utils packages and make it the same using shell

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,14 @@ RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=mod go build -a -o manager ./cmd/manag
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install -y shadow-utils && \ 
-    microdnf clean all && \ 
-    useradd kserve -m -u 1000
-RUN microdnf remove -y shadow-utils
+
+RUN mkdir -p /home/kserve && \
+    touch /etc/passwd /etc/group /etc/shadow && \
+    echo 'kserve:x:1000:1000::/home/kserve:/bin/bash' >> /etc/passwd && \
+    echo 'kserve:*:18573:0:99999:7:::' >> /etc/shadow && \
+    echo 'kserve:x:1000:' >> /etc/group && \
+    chown -R 1000:1000 /home/kserve
+
 COPY third_party/ /third_party/
 COPY --from=builder /go/src/github.com/kserve/kserve/manager /
 USER 1000:1000

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -17,10 +17,13 @@ RUN CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=mod go build -a -o agent ./cmd/agent
 # Copy the inference-agent into a thin image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
-RUN microdnf install -y shadow-utils && \ 
-    microdnf clean all && \ 
-    useradd kserve -m -u 1000
-RUN microdnf remove -y shadow-utils
+RUN mkdir -p /home/kserve && \
+    touch /etc/passwd /etc/group /etc/shadow && \
+    echo 'kserve:x:1000:1000::/home/kserve:/bin/bash' >> /etc/passwd && \
+    echo 'kserve:*:18573:0:99999:7:::' >> /etc/shadow && \
+    echo 'kserve:x:1000:' >> /etc/group && \
+    chown -R 1000:1000 /home/kserve
+    
 COPY third_party/ third_party/
 WORKDIR /ko-app
 COPY --from=builder /go/src/github.com/kserve/kserve/agent /ko-app/

--- a/router.Dockerfile
+++ b/router.Dockerfile
@@ -17,10 +17,14 @@ RUN CGO_ENABLED=0  go build -a -o router ./cmd/router
 
 # Copy the inference-router into a thin image
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
-RUN microdnf install -y shadow-utils && \ 
-    microdnf clean all && \ 
-    useradd kserve -m -u 1000
-RUN microdnf remove -y shadow-utils
+
+RUN mkdir -p /home/kserve && \
+    touch /etc/passwd /etc/group /etc/shadow && \
+    echo 'kserve:x:1000:1000::/home/kserve:/bin/bash' >> /etc/passwd && \
+    echo 'kserve:*:18573:0:99999:7:::' >> /etc/shadow && \
+    echo 'kserve:x:1000:' >> /etc/group && \
+    chown -R 1000:1000 /home/kserve
+    
 COPY third_party/ third_party/
 WORKDIR /ko-app
 COPY --from=builder /go/src/github.com/kserve/kserve/router /ko-app/


### PR DESCRIPTION
This is test change to remove shadow_utils package. However, still we need to find out how to solve the same issue for storage-initializer Dockerfile. This needs python packages and more

~~~
RUN microdnf install -y python39 python39-devel gcc libffi-devel openssl-devel krb5-workstation krb5-libs && microdnf clean all
~~~

This need more time to research