### PR TITLE
[2.10] Fix apiGroups in aggregate roles on manifests

### DIFF
--- a/config/overlays/odh/user-cluster-roles.yaml
+++ b/config/overlays/odh/user-cluster-roles.yaml
@@ -43,7 +43,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-view: "true"
 rules:
   - apiGroups:
-      - kubeflow.org
+      - serving.kserve.io
     resources:
       - servingruntimes
       - servingruntimes/status


### PR DESCRIPTION
Back-port opendatahub-io/kserve#401

Related to https://issues.redhat.com/browse/RHOAIENG-11008