### PR TITLE
add oauth-proxy image to params.env

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,3 +2,4 @@ kserve-controller=quay.io/modh/kserve-controller:nightly
 kserve-agent=quay.io/modh/kserve-agent:nightly
 kserve-router=quay.io/modh/kserve-router:nightly
 kserve-storage-initializer=quay.io/modh/kserve-storage-initializer:nightly
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:234af927030921ab8f7333f61f967b4b4dee37a1b3cf85689e9e63240dd62800


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/RHOAIENG-18357 
Add oauth-proxy image in params.env
The change is originally from [this commit](https://github.com/opendatahub-io/kserve/commit/5bdc954a8d096e9f88ccf01630d3b43fa441ea6f#diff-54fa1a6b6f0417fb589ec16b1b67064140cb5de547f52111e7bbad93045af97a) upstream but was not included in the auto-merge [commit](https://github.com/red-hat-data-services/kserve/commit/5bdc954a8d096e9f88ccf01630d3b43fa441ea6f). 