### PR TITLE
[Cherry-pick] Cleanup the filepath in createNewFile to avoid path traversal issue 

### DIFF
--- a/pkg/agent/storage/https.go
+++ b/pkg/agent/storage/https.go
@@ -142,6 +142,7 @@ func (h *HTTPSDownloader) extractHeaders() (headers map[string]string, err error
 }
 
 func createNewFile(fileFullName string) (*os.File, error) {
+	fileFullName = filepath.Clean(fileFullName)
 	if FileExists(fileFullName) {
 		if err := os.Remove(fileFullName); err != nil {
 			return nil, fmt.Errorf("file is unable to be deleted: %w", err)


### PR DESCRIPTION
Cherry picks https://github.com/kserve/kserve/pull/4205
[RHOAIENG-16692](https://issues.redhat.com/browse/RHOAIENG-16692) 

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.