### PR TITLE
[RHOAIENG-24212] - storage initializer - Fix storage intializer build for s390x

### DIFF
--- a/Dockerfiles/storage-initializer.Dockerfile.konflux
+++ b/Dockerfiles/storage-initializer.Dockerfile.konflux
@@ -7,7 +7,7 @@ RUN microdnf install -y \
     python3.11 python3.11-devel gcc libffi-devel openssl-devel krb5-workstation krb5-libs krb5-devel && \
     if [ "$(uname -m)" = "s390x" ] || [ "$(uname -m)" = "ppc64le" ]; then \
        echo "Installing packages" && \
-       microdnf install -y gcc-c++ cmake rust cargo; \
+       microdnf install -y gcc-c++ cmake rust cargo perl; \
     fi \
     && microdnf clean all \
     && alternatives --install /usr/bin/unversioned-python python /usr/bin/python3.11 1


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds  perl as a dependancy which is required to build hf-transfer
Fixes #
[RHOAIENG-24212](https://issues.redhat.com//browse/RHOAIENG-24212)
**Type of changes**
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update