### PR TITLE
RHOAIENG-24926: [rhoai-2.20] Change oauth proxy image to be compatible with multi arch

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,4 +2,4 @@ kserve-controller=quay.io/modh/kserve-controller@sha256:ebd5b4f7c816fc297055ecf4
 kserve-agent=quay.io/modh/kserve-agent@sha256:bc135bada2f5817cfbd111c868341bff3ab9e426f7b321fbb2deda1396bd7c4b
 kserve-router=quay.io/modh/kserve-router@sha256:324e2dab6be2cadbdcf137c9da67f9eb6fb1416b1ed77a5b06e2af181369b230
 kserve-storage-initializer=quay.io/modh/kserve-storage-initializer@sha256:baaa0a63ab0c8345da3fcb12eb35c58233e07cb2bb16772c6721c2ed26aad7fd
-oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08


### PR DESCRIPTION
CP of https://github.com/red-hat-data-services/kserve/commit/d360b6b5a99a6d1367e3a1779c6baff8d9163a53

fixes - https://issues.redhat.com/browse/RHOAIENG-24926