### PR TITLE
RHOAIENG-24926: [rhoai-2.21] change oauth proxy image to be compatible with multi arch

### DIFF
--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,4 +2,4 @@ kserve-controller=quay.io/modh/kserve-controller@sha256:293829ae03bf8e3b196eb056
 kserve-agent=quay.io/modh/kserve-agent@sha256:dec65c40cc0849c47f11777136077d305086728c7a957e8b4e07b9d8113a0b9f
 kserve-router=quay.io/modh/kserve-router@sha256:2a891a428467154395d21424b7b85e94b8130146027dac7bee43a85399d513f2
 kserve-storage-initializer=quay.io/modh/kserve-storage-initializer@sha256:48aceb43e3e30fcc0ea64bab1eb19f328ad2088edeb1c8c5570e653a7d77dda0
-oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:8507daed246d4d367704f7d7193233724acf1072572e1226ca063c066b858ecf
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08


### PR DESCRIPTION
CP of https://github.com/red-hat-data-services/kserve/commit/d360b6b5a99a6d1367e3a1779c6baff8d9163a53

