### PR TITLE
RHOAIENG-25750: Split syncable and static params

### DIFF
--- a/.github/workflows/instant-merge.yaml
+++ b/.github/workflows/instant-merge.yaml
@@ -6,6 +6,7 @@ on:
       - opened
     paths:
       - config/overlays/odh/params.env
+      - config/overlays/odh/params-synced.env
 
 permissions:
   contents: write

--- a/config/overlays/odh/kustomization.yaml
+++ b/config/overlays/odh/kustomization.yaml
@@ -27,6 +27,7 @@ replacements:
 configMapGenerator:
 - envs:
   - params.env
+  - params-synced.env
   name: kserve-parameters
 
 generatorOptions:

--- a/config/overlays/odh/params-synced.env
+++ b/config/overlays/odh/params-synced.env
@@ -1,0 +1,1 @@
+oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08

--- a/config/overlays/odh/params.env
+++ b/config/overlays/odh/params.env
@@ -2,4 +2,3 @@ kserve-controller=quay.io/opendatahub/kserve-controller:v0.14-latest
 kserve-agent=quay.io/opendatahub/kserve-agent:v0.14-latest
 kserve-router=quay.io/opendatahub/kserve-router:v0.14-latest
 kserve-storage-initializer=quay.io/opendatahub/kserve-storage-initializer:v0.14-latest
-oauth-proxy=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:bd49cfc8452b3d96467cc222db9487e120abc6cc5ba81349c6b3703706f36a08


### PR DESCRIPTION
**What this PR does / why we need it**:

As we've noticed during a blocker report, some image params aren't
synced from the other repository, this leads to outdated image
dependencies or requires manual (and forgottable) syncs.

With this patch, we'll be syncing automatically `params-synced.env`
file while `params.env` remains static, excluded from the auto-sync
and it will be manually updated (or through existing GH workflows).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.