### PR TITLE
Configure Renovate for Red Hat image digests and branch-based updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "baseBranches": ["rhoai-2.22*"],
+  "regexManagers": [
+    {
+      "fileMatch": [".*\\.env$", ".*\\.json$"],
+      "matchStrings": [
+        "^([a-zA-Z0-9_-]+)=(?<depName>[^@=]+)@sha256:(?<currentValue>[a-f0-9]{64})$"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "redhat"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["*"],
+      "matchDepTypes": ["regex"],
+      "matchBaseBranches": ["rhoai-2.22*"],
+      "depNameTemplate": "{{depName}}:rhoai-2.22"
+    }
+  ]
+}


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/RHOAIENG-27293

This PR introduces a Renovate configuration to automate updates of container image digests in .env and .json files, specifically tailored for Red Hat OpenShift AI Engineering workflows. Key features:
- Regex Managers: Match and update image digests in all .env and .json files using a custom regex.
- Red Hat Image Support: Use the redhat datasource and versioning template to ensure compatibility with Red Hat image versioning and registry conventions.
- Tag-based Digest Updates: Update digests to match the SHA256 of the rhoai-2.21 or rhoai-2.22 image tags, not just the latest tag.
- Branch-based Rules: Restrict digest updates so that only branches starting with rhoai-2.21 receive updates from the rhoai-2.21 tag, and likewise for rhoai-2.22. Uses both top-level baseBranches and matchBaseBranches in packageRules for precise control.
- Future-proof: Easily extendable to support additional versioned branches and tags as needed.

This file is not intended to be maintained manually, but through https://github.com/red-hat-data-services/konflux-central

Background:
This work is part of the initiative to eliminate quay.io usage for RHOAI production releases and to ensure all image references are up-to-date and compliant with Red Hat registry standards.