### PR TITLE
Revert setting PYO3_PYTHON env variable in storage-initializer.Dockerfile.konflux

### DIFF
--- a/Dockerfiles/storage-initializer.Dockerfile.konflux
+++ b/Dockerfiles/storage-initializer.Dockerfile.konflux
@@ -23,7 +23,6 @@ RUN /usr/bin/python3.11 -m venv ${POETRY_HOME} && ${POETRY_HOME}/bin/pip install
 # Activate virtual env
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PYO3_PYTHON=${VENV_PATH}/bin/python
 RUN /usr/bin/python3.11 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
@@ -48,7 +47,6 @@ COPY third_party third_party
 # Activate virtual env
 ARG VENV_PATH
 ENV VIRTUAL_ENV=${VENV_PATH}
-ENV PYO3_PYTHON=${VENV_PATH}/bin/python
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN microdnf install -y  \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

This reverts commit 02712feb163142e28ad813bd2a6b3534cf66e46c.

It was found that the issue is due to the version of the `hf-xet` package used, not the python interpreter passed to `matruin`. The installation of `hf-xet` using `maturin` failed because `hf-xet` version 1.0.5 does not have the expected file structure required for `maturin` installation. A package upgrade to version >=1.1.2 should resolve this.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.