### PR TITLE
add localmodel and localmodel-agent Konflux Dockerfiles

### DIFF
--- a/Dockerfiles/localmodel-agent.Dockerfile.konflux
+++ b/Dockerfiles/localmodel-agent.Dockerfile.konflux
@@ -1,0 +1,29 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+
+USER root
+
+# Copy in the go src
+WORKDIR /go/src/github.com/kserve/kserve
+COPY go.mod  go.mod
+COPY go.sum  go.sum
+
+COPY cmd/    cmd/
+COPY pkg/    pkg/
+
+# Build
+RUN . /cachi2/cachi2.env && \
+     CGO_ENABLED=0 GOOS=linux go build -a -o localmodelnode-agent ./cmd/localmodelnode
+
+# Generate third-party licenses
+COPY LICENSE LICENSE
+# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
+RUN . /cachi2/cachi2.env && \
+     go tool go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown" && \
+     go tool go-licenses save --save_path third_party/library ./cmd/localmodelnode
+
+# Copy the controller-manager into a thin image
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /go/src/github.com/kserve/kserve/third_party /third_party
+COPY --from=builder /go/src/github.com/kserve/kserve/localmodelnode-agent /manager
+ENTRYPOINT ["/manager"]

--- a/Dockerfiles/localmodel.Dockerfile.konflux
+++ b/Dockerfiles/localmodel.Dockerfile.konflux
@@ -1,0 +1,29 @@
+# Build the manager binary
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+
+USER root
+
+# Copy in the go src
+WORKDIR /go/src/github.com/kserve/kserve
+COPY go.mod  go.mod
+COPY go.sum  go.sum
+
+COPY cmd/    cmd/
+COPY pkg/    pkg/
+
+# Build
+RUN . /cachi2/cachi2.env && \
+     CGO_ENABLED=0 GOOS=linux go build -a -o localmodel-manager ./cmd/localmodel
+
+# Generate third-party licenses
+COPY LICENSE LICENSE
+# Forbidden Licenses: https://github.com/google/licenseclassifier/blob/e6a9bb99b5a6f71d5a34336b8245e305f5430f99/license_type.go#L341
+RUN . /cachi2/cachi2.env && \
+     go tool go-licenses check ./cmd/... ./pkg/... --disallowed_types="forbidden,unknown" && \
+     go tool go-licenses save --save_path third_party/library ./cmd/localmodel
+
+# Copy the controller-manager into a thin image
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /go/src/github.com/kserve/kserve/third_party /third_party
+COPY --from=builder /go/src/github.com/kserve/kserve/localmodel-manager /manager
+ENTRYPOINT ["/manager"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://issues.redhat.com/browse/RHOAIENG-24551 

- added localmodel.Dockerfile.konflux and localmodel-agent.Dockerfile.konflux to enable konflux builds of the localmodel images which are needed for the ModelCache feature 
- hermetic build tested by DevTestOps [here](https://issues.redhat.com/browse/RHOAIENG-24551?focusedId=27826107&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27826107)

**Re-running failed tests**

- `/rerun-all` - rerun all failed workflows.
- `/rerun-workflow <workflow name>` - rerun a specific failed workflow. Only one workflow name can be specified. Multiple /rerun-workflow commands are allowed per comment.