### PR TITLE
fix(router): readiness logic for multiple ctrl statuses (#908)

### DIFF
--- a/pkg/controller/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/llmisvc/router_gateway_conditions_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayapi "sigs.k8s.io/gateway-api/apis/v1"
@@ -33,13 +35,11 @@ import (
 
 func TestGatewayConditionsEvaluation(t *testing.T) {
 	tests := []struct {
-		name                    string
-		llmSvc                  *v1alpha1.LLMInferenceService
-		gateways                []*gatewayapi.Gateway
-		expectedRouterReady     bool
-		expectedConditionReason string
-		expectedErrorMsg        string
-		expectConditionUnset    bool // true when condition should remain nil
+		name             string
+		llmSvc           *v1alpha1.LLMInferenceService
+		gateways         []*gatewayapi.Gateway
+		expectedErrorMsg string
+		assertCondition  func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc
 	}{
 		{
 			name: "single ready gateway - router should be ready",
@@ -59,8 +59,7 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
 				),
 			},
-			expectedRouterReady:     true,
-			expectedConditionReason: "",
+			assertCondition: assertRouterReady,
 		},
 		{
 			name: "single not ready gateway - router should not be ready",
@@ -80,8 +79,9 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					WithProgrammedCondition(metav1.ConditionFalse, "NotReady", "Gateway is not ready"),
 				),
 			},
-			expectedRouterReady:     false,
-			expectedConditionReason: "GatewaysNotReady",
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
 		},
 		{
 			name: "multiple gateways - all ready",
@@ -105,8 +105,7 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway 2 is ready"),
 				),
 			},
-			expectedRouterReady:     true,
-			expectedConditionReason: "",
+			assertCondition: assertRouterReady,
 		},
 		{
 			name: "multiple gateways - some not ready",
@@ -130,8 +129,9 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					WithProgrammedCondition(metav1.ConditionFalse, "NotReady", "Gateway is not ready"),
 				),
 			},
-			expectedRouterReady:     false,
-			expectedConditionReason: "GatewaysNotReady",
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
 		},
 		{
 			name: "gateway with no programmed condition - should be not ready",
@@ -150,8 +150,9 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					// No programmed condition set
 				),
 			},
-			expectedRouterReady:     false,
-			expectedConditionReason: "GatewaysNotReady",
+			assertCondition: func(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, gatewayCondition, "GatewaysNotReady")
+			},
 		},
 		{
 			name: "gateway not found - should return error",
@@ -163,9 +164,8 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					Namespace: "test-ns",
 				}),
 			),
-			gateways:            []*gatewayapi.Gateway{},
-			expectedRouterReady: false,
-			expectedErrorMsg:    "failed to get Gateway",
+			gateways:         []*gatewayapi.Gateway{},
+			expectedErrorMsg: "failed to get Gateway",
 		},
 		{
 			name: "no gateway refs - should skip evaluation",
@@ -174,8 +174,8 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 				WithModelURI("hf://test/model"),
 				// No gateway refs
 			),
-			gateways:             []*gatewayapi.Gateway{},
-			expectConditionUnset: true, // Should not set any router condition
+			gateways:        []*gatewayapi.Gateway{},
+			assertCondition: assertConditionUnset,
 		},
 		{
 			name: "gateway without namespace uses LLMInferenceService namespace",
@@ -194,7 +194,7 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 					WithProgrammedCondition(metav1.ConditionTrue, "Ready", "Gateway is ready"),
 				),
 			},
-			expectedRouterReady: true,
+			assertCondition: assertRouterReady,
 		},
 	}
 
@@ -203,14 +203,12 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 			g := NewGomegaWithT(t)
 			ctx := t.Context()
 
-			// Setup scheme and fake client
 			scheme := runtime.NewScheme()
 			err := v1alpha1.AddToScheme(scheme)
 			g.Expect(err).ToNot(HaveOccurred())
 			err = gatewayapi.Install(scheme)
 			g.Expect(err).ToNot(HaveOccurred())
 
-			// Prepare objects for fake client
 			var objects []client.Object
 			objects = append(objects, tt.llmSvc)
 			for _, gw := range tt.gateways {
@@ -222,12 +220,10 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 				WithObjects(objects...).
 				Build()
 
-			// Create reconciler
 			reconciler := &llmisvc.LLMInferenceServiceReconciler{
 				Client: fakeClient,
 			}
 
-			// Execute the evaluation
 			err = reconciler.EvaluateGatewayConditions(ctx, tt.llmSvc)
 
 			if tt.expectedErrorMsg != "" {
@@ -238,34 +234,13 @@ func TestGatewayConditionsEvaluation(t *testing.T) {
 
 			g.Expect(err).ToNot(HaveOccurred())
 
-			// Aggregate gateway conditions into router readiness
 			tt.llmSvc.DetermineRouterReadiness()
 
-			// Check the router condition
 			routerCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha1.RouterReady)
-			// Also check the gateway condition was set properly
 			gatewayCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha1.GatewaysReady)
-			switch {
-			case tt.expectConditionUnset:
-				g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
-				g.Expect(gatewayCondition).To(BeNil(), "Gateway condition should not be set when no gateway refs")
-			case tt.expectedRouterReady:
-				g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
-				g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
-				g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
-				g.Expect(gatewayCondition.IsTrue()).To(BeTrue(), "Gateways should be ready")
-				if tt.expectedConditionReason != "" {
-					g.Expect(routerCondition.Reason).To(Equal(tt.expectedConditionReason))
-				}
-			default:
-				g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
-				g.Expect(routerCondition.IsFalse()).To(BeTrue(), "Router should not be ready")
-				g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
-				g.Expect(gatewayCondition.IsFalse()).To(BeTrue(), "Gateways should not be ready")
-				if tt.expectedConditionReason != "" {
-					// The router condition reason should propagate from gateway condition
-					g.Expect(routerCondition.Reason).To(Equal(gatewayCondition.Reason))
-				}
+
+			if tt.assertCondition != nil {
+				tt.assertCondition(routerCondition, gatewayCondition)(g)
 			}
 		})
 	}
@@ -321,6 +296,142 @@ func TestIsGatewayReady(t *testing.T) {
 			result := llmisvc.IsGatewayReady(tt.gateway)
 
 			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestHTTPRouteConditionsEvaluation(t *testing.T) {
+	tests := []struct {
+		name             string
+		llmSvc           *v1alpha1.LLMInferenceService
+		httpRoutes       []*gatewayapi.HTTPRoute
+		expectedErrorMsg string
+		createAssertion  func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc
+	}{
+		{
+			name: "HTTPRoute with multiple controllers - should be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha1.LLMInferenceService]("llm"),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithHTTPRouteRefs(HTTPRouteRef("facebook-opt-125m-single-simulated-kserve-route")),
+			),
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				HTTPRoute("facebook-opt-125m-single-simulated-kserve-route",
+					InNamespace[*gatewayapi.HTTPRoute]("llm"),
+					WithParentRefs(GatewayParentRef("openshift-ai-inference", "openshift-ingress")),
+					WithHTTPRule(
+						Matches(PathPrefixMatch("/llm/facebook-opt-125m-single-simulated")),
+						BackendRefs(ServiceRef("facebook-opt-125m-single-simulated-kserve-workload-svc", 8000, 1)),
+						Timeouts("0s", "0s"),
+						Filters(gatewayapi.HTTPRouteFilter{
+							Type: gatewayapi.HTTPRouteFilterURLRewrite,
+							URLRewrite: &gatewayapi.HTTPURLRewriteFilter{
+								Path: &gatewayapi.HTTPPathModifier{
+									Type:               gatewayapi.PrefixMatchHTTPPathModifier,
+									ReplacePrefixMatch: ptr.To("/"),
+								},
+							},
+						}),
+					),
+					WithHTTPRouteMultipleControllerStatus(
+						GatewayParentRef("openshift-ai-inference", "openshift-ingress"),
+						KuadrantControllerStatus,
+						GatewayAPIControllerStatus,
+					),
+				),
+			},
+			createAssertion: assertRouterReady,
+		},
+		{
+			name: "HTTPRoute with standard controller only - should be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha1.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("test-route")),
+			),
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				HTTPRoute("test-route",
+					InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteReadyStatus("openshift.io/gateway-controller/v1"),
+				),
+			},
+			createAssertion: assertRouterReady,
+		},
+		{
+			name: "HTTPRoute not ready - should not be ready",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha1.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				WithHTTPRouteRefs(HTTPRouteRef("not-ready-route")),
+			),
+			httpRoutes: []*gatewayapi.HTTPRoute{
+				HTTPRoute("not-ready-route",
+					InNamespace[*gatewayapi.HTTPRoute]("test-ns"),
+					WithParentRefs(GatewayParentRef("test-gateway", "test-ns")),
+					WithHTTPRouteNotReadyStatus("openshift.io/gateway-controller/v1", "NotAccepted", "Route was not accepted"),
+				),
+			},
+			createAssertion: func(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+				return assertRouterNotReadyWithReason(routerCondition, httpRouteCondition, "HTTPRoutesNotReady")
+			},
+		},
+		{
+			name: "no HTTPRoute refs - should skip evaluation",
+			llmSvc: LLMInferenceService("test-llm",
+				InNamespace[*v1alpha1.LLMInferenceService]("test-ns"),
+				WithModelURI("hf://test/model"),
+				// No HTTPRoute refs
+			),
+			httpRoutes:      []*gatewayapi.HTTPRoute{},
+			createAssertion: assertHTTPRouteConditionUnset,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			ctx := t.Context()
+
+			scheme := runtime.NewScheme()
+			err := v1alpha1.AddToScheme(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+			err = gatewayapi.Install(scheme)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			var objects []client.Object
+			objects = append(objects, tt.llmSvc)
+			for _, route := range tt.httpRoutes {
+				objects = append(objects, route)
+			}
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			reconciler := &llmisvc.LLMInferenceServiceReconciler{
+				Client: fakeClient,
+			}
+
+			err = reconciler.EvaluateHTTPRouteConditions(ctx, tt.llmSvc)
+
+			if tt.expectedErrorMsg != "" {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.expectedErrorMsg))
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+
+			tt.llmSvc.DetermineRouterReadiness()
+
+			routerCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha1.RouterReady)
+			httpRouteCondition := tt.llmSvc.GetStatus().GetCondition(v1alpha1.HTTPRoutesReady)
+
+			if tt.createAssertion != nil {
+				tt.createAssertion(routerCondition, httpRouteCondition)(g)
+			}
 		})
 	}
 }
@@ -427,5 +538,57 @@ func TestFetchReferencedGateways(t *testing.T) {
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(gateways).To(HaveLen(tt.expectedCount))
 		})
+	}
+}
+
+// assertConditionsFunc defines the signature for condition assertion functions
+type assertConditionsFunc func(g *WithT)
+
+// assertConditionUnset returns a function that verifies the router is ready but gateway condition is not set
+func assertConditionUnset(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(gatewayCondition).To(BeNil(), "Gateway condition should not be set when no gateway refs")
+	}
+}
+
+// assertRouterReady returns a function that verifies both router and gateway conditions are set and ready
+func assertRouterReady(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsTrue()).To(BeTrue(), "Gateways should be ready")
+	}
+}
+
+// assertRouterNotReady returns a function that verifies both router and gateway conditions are set but not ready
+func assertRouterNotReady(routerCondition, gatewayCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsFalse()).To(BeTrue(), "Router should not be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsFalse()).To(BeTrue(), "Gateways should not be ready")
+	}
+}
+
+// assertRouterNotReadyWithReason returns a function that verifies conditions are not ready and checks the reason
+func assertRouterNotReadyWithReason(routerCondition, gatewayCondition *apis.Condition, expectedReason string) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition).ToNot(BeNil(), "Router condition should be set")
+		g.Expect(routerCondition.IsFalse()).To(BeTrue(), "Router should not be ready")
+		g.Expect(gatewayCondition).ToNot(BeNil(), "Gateway condition should be set")
+		g.Expect(gatewayCondition.IsFalse()).To(BeTrue(), "Gateways should not be ready")
+		g.Expect(routerCondition.Reason).To(Equal(gatewayCondition.Reason))
+		g.Expect(routerCondition.Reason).To(Equal(expectedReason))
+	}
+}
+
+// assertHTTPRouteConditionUnset returns a function that verifies the router is ready and HTTPRoute condition is set to ready
+func assertHTTPRouteConditionUnset(routerCondition, httpRouteCondition *apis.Condition) assertConditionsFunc {
+	return func(g *WithT) {
+		g.Expect(routerCondition.IsTrue()).To(BeTrue(), "Router should be ready")
+		g.Expect(httpRouteCondition).ToNot(BeNil(), "HTTPRoute condition should be set")
+		g.Expect(httpRouteCondition.IsTrue()).To(BeTrue(), "HTTPRoute condition should be ready when no HTTPRoute refs")
 	}
 }


### PR DESCRIPTION
When `HTTPRoute` has status from multiple controllers, the current logic fails to recognize it, expecting status only from the gateway controller, with top-level standard condition `Accepted` being `true`.

This change handles the scenario of the status with multiple controller updates, adjusting the logic to check for the standard condition.

If `gatewayapi.RouteConditionAccepted` is not found in all reported conditions, it will be reported as missing.

Example: https://gist.github.com/bartoszmajsak/4329206afe107357afdcb9b92ed778bd

Backport of https://github.com/opendatahub-io/kserve/pull/908