### PR TITLE
fix(webhook): relax HTTPRoute/Gateway validation (#911)

### DIFF
--- a/pkg/controller/llmisvc/fixture/gwapi_builders.go
+++ b/pkg/controller/llmisvc/fixture/gwapi_builders.go
@@ -283,6 +283,12 @@ func WithBackendRefs(refs ...gatewayapi.HTTPBackendRef) HTTPRouteRuleOption {
 	}
 }
 
+func WithHTTPRouteGatewayRef(references ...gatewayapi.ParentReference) HTTPRouteOption {
+	return func(route *gatewayapi.HTTPRoute) {
+		route.Spec.ParentRefs = append(route.Spec.ParentRefs, references...)
+	}
+}
+
 func BackendRefInferencePool(name string) gatewayapi.HTTPBackendRef {
 	return gatewayapi.HTTPBackendRef{
 		BackendRef: gatewayapi.BackendRef{
@@ -332,10 +338,6 @@ func WithHTTPRule(ruleOpts ...HTTPRouteRuleOption) HTTPRouteOption {
 
 func Matches(matches ...gatewayapi.HTTPRouteMatch) HTTPRouteRuleOption {
 	return WithMatches(matches...)
-}
-
-func BackendRefs(refs ...gatewayapi.HTTPBackendRef) HTTPRouteRuleOption {
-	return WithBackendRefs(refs...)
 }
 
 func Timeouts(backendTimeout, requestTimeout string) HTTPRouteRuleOption {

--- a/pkg/controller/llmisvc/router_gateway_conditions_test.go
+++ b/pkg/controller/llmisvc/router_gateway_conditions_test.go
@@ -321,7 +321,7 @@ func TestHTTPRouteConditionsEvaluation(t *testing.T) {
 					WithParentRefs(GatewayParentRef("openshift-ai-inference", "openshift-ingress")),
 					WithHTTPRule(
 						Matches(PathPrefixMatch("/llm/facebook-opt-125m-single-simulated")),
-						BackendRefs(ServiceRef("facebook-opt-125m-single-simulated-kserve-workload-svc", 8000, 1)),
+						WithBackendRefs(ServiceRef("facebook-opt-125m-single-simulated-kserve-workload-svc", 8000, 1)),
 						Timeouts("0s", "0s"),
 						Filters(gatewayapi.HTTPRouteFilter{
 							Type: gatewayapi.HTTPRouteFilterURLRewrite,

--- a/pkg/controller/llmisvc/validation/llminferenceservice_validator.go
+++ b/pkg/controller/llmisvc/validation/llminferenceservice_validator.go
@@ -113,23 +113,6 @@ func (l *LLMInferenceServiceValidator) validateRouterCrossFieldConstraints(llmSv
 	httpRouteRefs := httpRoutePath.Child("refs")
 	httpRouteSpec := httpRoutePath.Child("spec")
 
-	zero := v1alpha1.GatewayRoutesSpec{}
-	if ptr.Deref(router.Route, zero) == zero && router.Gateway != nil && router.Gateway.Refs != nil {
-		return field.ErrorList{
-			field.Invalid(
-				gwRefsPath,
-				router.Gateway.Refs,
-				fmt.Sprintf("unsupported configuration: custom gateway ('%s') cannot be used with managed route ('%s: {}'); "+
-					"either provide your own HTTP routes ('%s') or remove '%s' to use the managed gateway",
-					gwRefsPath,
-					routePath,
-					httpRouteRefs,
-					gwRefsPath,
-				),
-			),
-		}
-	}
-
 	httpRoute := router.Route.HTTP
 	if httpRoute == nil {
 		return field.ErrorList{}
@@ -162,13 +145,14 @@ func (l *LLMInferenceServiceValidator) validateRouterCrossFieldConstraints(llmSv
 		))
 	}
 
-	// Managed route spec cannot be used with user-defined gateway refs
-	if httpRoute.Spec != nil && router.Gateway != nil && len(router.Gateway.Refs) > 0 {
+	// Managed route spec referring to the gateway cannot be used with user-defined gateway refs
+	if httpRoute.Spec != nil && len(httpRoute.Spec.ParentRefs) > 0 &&
+		router.Gateway != nil && len(router.Gateway.Refs) > 0 {
 		allErrs = append(allErrs, field.Invalid(
 			httpRoutePath.Child("spec"),
 			httpRoute.Spec,
 			fmt.Sprintf("unsupported configuration: managed HTTP route spec ('%s') cannot be used with custom gateway refs ('%s'); "+
-				"either remove '%s' or '%s'",
+				"either remove '%s' or '%s.parentRefs'",
 				httpRouteSpec, gwRefsPath, gwRefsPath, httpRouteSpec,
 			),
 		))

--- a/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
+++ b/pkg/controller/llmisvc/validation/llminferenceservice_validator_int_test.go
@@ -83,7 +83,7 @@ var _ = Describe("LLMInferenceService webhook validation", func() {
 				fixture.WithHTTPRouteSpec(&fixture.HTTPRoute("test-route",
 					fixture.WithHTTPRule(
 						fixture.Matches(fixture.PathPrefixMatch("/test")),
-						fixture.BackendRefs(fixture.ServiceRef("test-service", 80, 1)),
+						fixture.WithBackendRefs(fixture.ServiceRef("test-service", 80, 1)),
 					),
 				).Spec),
 			)
@@ -113,33 +113,17 @@ var _ = Describe("LLMInferenceService webhook validation", func() {
 			Expect(errValidation.Error()).To(ContainSubstring("cannot be used with a managed gateway"))
 		})
 
-		It("should reject LLMInferenceService with managed route and user-defined gateway refs", func(ctx SpecContext) {
-			// given
-			llmSvc := fixture.LLMInferenceService("test-spec-with-gateway-refs",
-				fixture.InNamespace[*v1alpha1.LLMInferenceService](nsName),
-				fixture.WithModelURI("hf://facebook/opt-125m"),
-				fixture.WithGatewayRefs(fixture.LLMGatewayRef("test-gateway", nsName)),
-				fixture.WithManagedRoute(),
-			)
-
-			// when
-			errValidation := envTest.Client.Create(ctx, llmSvc)
-
-			// then
-			Expect(errValidation).To(HaveOccurred())
-			Expect(errValidation.Error()).To(ContainSubstring("cannot be used with managed route"))
-		})
-
-		It("should reject LLMInferenceService with managed route spec and user-defined gateway refs", func(ctx SpecContext) {
+		It("should reject LLMInferenceService with managed route spec with gateway ref and user-defined gateway refs", func(ctx SpecContext) {
 			// given
 			llmSvc := fixture.LLMInferenceService("test-spec-with-gateway-refs",
 				fixture.InNamespace[*v1alpha1.LLMInferenceService](nsName),
 				fixture.WithModelURI("hf://facebook/opt-125m"),
 				fixture.WithGatewayRefs(fixture.LLMGatewayRef("test-gateway", nsName)),
 				fixture.WithHTTPRouteSpec(&fixture.HTTPRoute("test-route",
+					fixture.WithHTTPRouteGatewayRef(fixture.GatewayParentRef("test-gateway", nsName)),
 					fixture.WithHTTPRule(
 						fixture.Matches(fixture.PathPrefixMatch("/test")),
-						fixture.BackendRefs(fixture.ServiceRef("custom-backend", 8080, 1)),
+						fixture.WithBackendRefs(fixture.ServiceRef("custom-backend", 8080, 1)),
 						fixture.Timeouts("30s", "60s"),
 					),
 				).Spec),

--- a/test/e2e/llmisvc/README.md
+++ b/test/e2e/llmisvc/README.md
@@ -22,22 +22,32 @@ Tests are marked with both general and cluster-specific capability markers:
 - `@pytest.mark.cluster_nvidia` - NVIDIA GPU tests
 - `@pytest.mark.cluster_nvidia_roce` - NVIDIA ROCe tests
 - `@pytest.mark.cluster_intel` - Intel GPU tests
+- `@pytest.mark.llmd_simulator` - Tests using llm-d simulator instead of real model
 
-Examples:
-```bash
-# Run all LLM inference service tests
+## Examples
+
+### Run all LLM inference service tests 
+
+```shell
 pytest -m "llminferenceservice" test/e2e/llmisvc/
+```
 
-# Run only CPU tests
+### Run only CPU tests
+```shell
 pytest -m "llminferenceservice and cluster_cpu" test/e2e/llmisvc/
+```
 
-# Run only NVIDIA GPU tests
+### Run only NVIDIA GPU tests
+```shell
 pytest -m "llminferenceservice and cluster_nvidia" test/e2e/llmisvc/
+```
 
-# Run all GPU tests (any vendor)
+### Run all GPU tests (any vendor)
+```shell
 pytest -m "llminferenceservice and (cluster_amd or cluster_nvidia or cluster_intel)" test/e2e/llmisvc/
-
-# Run CPU and AMD GPU tests only
+```
+### Run CPU and AMD GPU tests only
+```shell
 pytest -m "llminferenceservice and (cluster_cpu or cluster_amd)" test/e2e/llmisvc/
 ```
 

--- a/test/e2e/llmisvc/test_llm_inference_service.py
+++ b/test/e2e/llmisvc/test_llm_inference_service.py
@@ -86,6 +86,24 @@ class TestCase:
         pytest.param(
             TestCase(
                 base_refs=[
+                    "router-with-gateway-ref",
+                    "router-with-managed-route",
+                    "model-fb-opt-125m",
+                    "workload-llmd-simulator",
+                ],
+                prompt="KServe is a",
+                before_test=[lambda: create_router_resources(
+                    gateways=[ROUTER_GATEWAYS[0]],
+                )],
+                after_test=[lambda: delete_router_resources(
+                    gateways=[ROUTER_GATEWAYS[0]],
+                )],
+            ),
+            marks=[pytest.mark.cluster_cpu, pytest.mark.cluster_single_node, pytest.mark.llmd_simulator],
+        ),
+        pytest.param(
+            TestCase(
+                base_refs=[
                     "router-managed",
                     "workload-single-cpu",
                     "model-fb-opt-125m",

--- a/test/e2e/pytest.ini
+++ b/test/e2e/pytest.ini
@@ -23,4 +23,6 @@ markers =
     cluster_amd: test targeting cluster with AMD
     cluster_intel: test targeting cluster with Intel
     cluster_nvidia: test targeting cluster with NVIDIA
+    cluster_nvidia_roce: test targeting cluster with NVIDIA ROCe
     cluster_single_node: test targeting single node cluster
+    llmd_simulator: test using llm-d simulator


### PR DESCRIPTION
Users should be able to attach custom Gateway while still relying on managed HTTPRoute. While controller already has the logic to support it, the webhook was previously rejecting as invalid, expecting that "bring your own" config is all-or-nothing scenario. This obviously is not desired when users want simply to attach their LLMInferenceService to another gateway.

- Webhook validation now permits such configuration, and only rejects when HTTPRoute Spec of LLMInferenceService is also set, treating it as invalid configuration and suggesting removal of parentRef in favor of the global Gateway defined as `.spec.router.gateway.refs` instead
- Adjusted EnvTests
- Introduced e2e test to cover this case that leverages llmd-simulator for faster feedback loop

Backporting https://github.com/opendatahub-io/kserve/pull/911