### PR TITLE
Fix hf-transfer build from source on s390x/ppc64le

### DIFF
--- a/Dockerfiles/storage-initializer.Dockerfile.konflux
+++ b/Dockerfiles/storage-initializer.Dockerfile.konflux
@@ -38,6 +38,7 @@ RUN if [ "$(uname -m)" = "s390x" ] || [ "$(uname -m)" = "ppc64le" ]; then \
 
 RUN cd storage && \
     if [ "$(uname -m)" = "s390x" ] || [ "$(uname -m)" = "ppc64le" ]; then \
+       export PATH=/root/.cargo/bin:$PATH && \
        export GRPC_PYTHON_BUILD_SYSTEM_OPENSSL=true && \
        uv pip install /hf_xet/wheels/*.whl ; \
     fi && \


### PR DESCRIPTION
On s390x/ppc64le, hf-transfer has no prebuilt wheels and must be compiled from source during uv sync. This requires cargo to be in PATH. Add /root/.cargo/bin to PATH in the uv sync step so maturin can find cargo when building hf-transfer.
