### PR TITLE
fix(rawdeploy): probe updates via local merge+update; retry ISVC status

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	operatorv1beta1 "knative.dev/operator/pkg/apis/operator/v1beta1"
 	"knative.dev/pkg/apis"
 	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
@@ -284,24 +285,29 @@ func (r *InferenceServiceReconciler) updateStatus(desiredService *v1beta1api.Inf
 	// set the DeploymentMode used for the InferenceService in the status
 	desiredService.Status.DeploymentMode = string(deploymentMode)
 
-	existingService := &v1beta1api.InferenceService{}
 	namespacedName := types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}
-	if err := r.Get(context.TODO(), namespacedName, existingService); err != nil {
-		return err
-	}
-	wasReady := inferenceServiceReadiness(existingService.Status)
-	if inferenceServiceStatusEqual(existingService.Status, desiredService.Status, deploymentMode) {
-		// If we didn't change anything then don't call updateStatus.
-		// This is important because the copy we loaded from the informer's
-		// cache may be stale and we don't want to overwrite a prior update
-		// to status with this stale state.
-	} else if err := r.Status().Update(context.TODO(), desiredService); err != nil {
-		r.Log.Error(err, "Failed to update InferenceService status", "InferenceService", desiredService.Name)
-		r.Recorder.Eventf(desiredService, v1.EventTypeWarning, "UpdateFailed",
-			"Failed to update status for InferenceService %q: %v", desiredService.Name, err)
-		return errors.Wrapf(err, "fails to update InferenceService status")
-	} else {
-		// If there was a difference and there was no error.
+	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		existingService := &v1beta1api.InferenceService{}
+		if err := r.Get(context.TODO(), namespacedName, existingService); err != nil {
+			return err
+		}
+		wasReady := inferenceServiceReadiness(existingService.Status)
+		if inferenceServiceStatusEqual(existingService.Status, desiredService.Status, deploymentMode) {
+			// If we didn't change anything then don't call updateStatus.
+			// This is important because the copy we loaded from the informer's
+			// cache may be stale and we don't want to overwrite a prior update
+			// to status with this stale state.
+			return nil
+		}
+		// Apply status onto the freshly loaded object so metadata.resourceVersion matches the
+		// apiserver (the reconciler's desiredService still carries the RV from Reconcile's Get).
+		existingService.Status = *desiredService.Status.DeepCopy()
+		if err := r.Status().Update(context.TODO(), existingService); err != nil {
+			r.Log.Error(err, "Failed to update InferenceService status", "InferenceService", desiredService.Name)
+			r.Recorder.Eventf(desiredService, v1.EventTypeWarning, "UpdateFailed",
+				"Failed to update status for InferenceService %q: %v", desiredService.Name, err)
+			return errors.Wrapf(err, "fails to update InferenceService status")
+		}
 		isReady := inferenceServiceReadiness(desiredService.Status)
 		isReadyFalse := inferenceServiceReadinessFalse(desiredService.Status)
 		if wasReady && isReadyFalse { // Moved to NotReady State
@@ -311,8 +317,8 @@ func (r *InferenceServiceReconciler) updateStatus(desiredService *v1beta1api.Inf
 			r.Recorder.Eventf(desiredService, v1.EventTypeNormal, string(InferenceServiceReadyState),
 				fmt.Sprintf("InferenceService [%v] is Ready", desiredService.GetName()))
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func inferenceServiceReadiness(status v1beta1api.InferenceServiceStatus) bool {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -21,15 +21,14 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/google/go-cmp/cmp/cmpopts"
 	appsv1 "k8s.io/api/apps/v1"
@@ -605,7 +604,6 @@ func addGPUResourceToDeployment(deployment *appsv1.Deployment, targetContainerNa
 func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 	for _, deployment := range r.DeploymentList {
 		// Reconcile Deployment
-		originalDeployment := &appsv1.Deployment{}
 		checkResult, _, err := r.checkDeploymentExist(r.client, deployment)
 		if err != nil {
 			return nil, err
@@ -617,126 +615,29 @@ func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 		case constants.CheckResultCreate:
 			opErr = r.client.Create(context.TODO(), deployment)
 		case constants.CheckResultUpdate:
-			// get the current deployment
-			_ = r.client.Get(context.TODO(), types.NamespacedName{Name: deployment.Name, Namespace: deployment.Namespace}, originalDeployment)
-			// we need to remove the Replicas field from the deployment spec
+			// Use a full spec Update instead of strategic merge patch. Strategic merge can merge
+			// incompatible probe handler fields (e.g. httpGet retained when switching to exec),
+			// which makes the object invalid (more than one handler type).
+			desired := deployment.DeepCopy()
 
-			// Check if there are any envs to remove
-			// If there, its value will be set to "delete" so we can update the patchBytes with
-			// "patch": "delete"
-			// The strategic merge patch does not remove items from list just by removing it from the patch,
-			// to delete lists items using strategic merge patch, the $patch delete pattern is used.
-			// Example:
-			// - env:
-			//   - "name": "ENV1",
-			//     "$patch": "delete"
-			for i, deploymentC := range deployment.Spec.Template.Spec.Containers {
-				envs := []corev1.EnvVar{}
-				for _, OriginalC := range originalDeployment.Spec.Template.Spec.Containers {
-					if deploymentC.Name == OriginalC.Name {
-						envsToRemove, envsToKeep := utils.CheckEnvsToRemove(deploymentC.Env, OriginalC.Env)
-						if len(envsToRemove) > 0 {
-							envs = append(envs, envsToKeep...)
-							envs = append(envs, envsToRemove...)
-						} else {
-							envs = deploymentC.Env
-						}
-					}
+			opErr = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				cur := &appsv1.Deployment{}
+				if err := r.client.Get(context.TODO(), types.NamespacedName{
+					Name:      desired.Name,
+					Namespace: desired.Namespace,
+				}, cur); err != nil {
+					return err
 				}
-				deployment.Spec.Template.Spec.Containers[i].Env = envs
-			}
-
-			originalDeployment.Spec.Replicas = nil
-			curJson, err := json.Marshal(originalDeployment)
-			if err != nil {
-				return nil, err
-			}
-			// To avoid the conflict between HPA and Deployment,
-			// we need to remove the Replicas field from the deployment spec
-			deployment.Spec.Replicas = nil
-
-			imagePullSecretsDesired := deployment.Spec.Template.Spec.ImagePullSecrets
-			originalDeploymentPullSecrets := originalDeployment.Spec.Template.Spec.ImagePullSecrets
-			imagePullSecretsToRemove := []string{}
-			for _, secret := range originalDeploymentPullSecrets {
-				found := false
-				for _, desiredSecret := range imagePullSecretsDesired {
-					if secret.Name == desiredSecret.Name {
-						found = true
-						break
-					}
-				}
-				if !found {
-					imagePullSecretsToRemove = append(imagePullSecretsToRemove, secret.Name)
-				}
-			}
-
-			modJson, err := json.Marshal(deployment)
-			if err != nil {
-				return nil, err
-			}
-
-			// Generate the strategic merge patch between the current and modified JSON
-			patchByte, err := strategicpatch.StrategicMergePatch(curJson, modJson, appsv1.Deployment{})
-			if err != nil {
-				return nil, err
-			}
-
-			// Patch the deployment object with the strategic merge patch
-			patchByte = []byte(strings.ReplaceAll(string(patchByte), "\"value\":\""+utils.PLACEHOLDER_FOR_DELETION+"\"", "\"$patch\":\"delete\""))
-
-			// The strategic merge patch does not remove items from list just by removing it from the patch,
-			// to delete lists items using strategic merge patch, the $patch delete pattern is used.
-			// Example:
-			// imagePullSecrets:
-			//   - "name": "pull-secret-1",
-			//     "$patch": "delete"
-			if len(imagePullSecretsToRemove) > 0 {
-				patchJson := map[string]interface{}{}
-				err = json.Unmarshal(patchByte, &patchJson)
-				if err != nil {
-					return nil, err
-				}
-				spec, ok := patchJson["spec"].(map[string]interface{})
-				if !ok {
-					return nil, errors.New("spec not found")
-				}
-				template, ok := spec["template"].(map[string]interface{})
-				if !ok {
-					return nil, errors.New("template not found")
-				}
-				specTemplate, ok := template["spec"].(map[string]interface{})
-				if !ok {
-					return nil, errors.New("template.spec not found")
-				}
-
-				// Ensure imagePullSecrets is a slice, defaulting to an empty slice if nil.
-				ipsField, exists := specTemplate["imagePullSecrets"]
-				var imagePullSecrets []interface{}
-				if exists && ipsField != nil {
-					var ok bool
-					imagePullSecrets, ok = ipsField.([]interface{})
-					if !ok {
-						return nil, errors.New("imagePullSecrets is not the expected type")
-					}
-				} else {
-					imagePullSecrets = []interface{}{}
-				}
-
-				for _, secret := range imagePullSecretsToRemove {
-					for _, secretMap := range imagePullSecrets {
-						if secretMap.(map[string]interface{})["name"] == secret {
-							secretMap.(map[string]interface{})["$patch"] = "delete"
-						}
-					}
-				}
-				patchJson["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["imagePullSecrets"] = imagePullSecrets
-				patchByte, err = json.Marshal(patchJson)
-				if err != nil {
-					return nil, err
-				}
-			}
-			opErr = r.client.Patch(context.TODO(), deployment, kclient.RawPatch(types.StrategicMergePatchType, patchByte))
+				updated := cur.DeepCopy()
+				updated.Labels = desired.Labels
+				updated.Annotations = desired.Annotations
+				newSpec := desired.Spec.DeepCopy()
+				// Match prior patch behavior: do not change replica count via this reconcile path
+				// (diff ignores Replicas; HPA or other controllers own the live value).
+				newSpec.Replicas = cur.Spec.Replicas
+				updated.Spec = *newSpec
+				return r.client.Update(context.TODO(), updated)
+			})
 
 		case constants.CheckResultDelete:
 			log.Info("Deleting deployment", "namespace", deployment.Namespace, "name", deployment.Name)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler.go
@@ -21,12 +21,14 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
@@ -422,6 +424,37 @@ func generateCookieSecret() (string, error) {
 	return base64.StdEncoding.EncodeToString(secret), nil
 }
 
+// syncContainerProbesFromDesired overwrites liveness, readiness, and startup probes on dst's
+// containers with probes from identically named containers in src. The result of applying a
+// strategic merge patch locally can still deep-merge probes incorrectly when persisted via
+// another strategic patch to the API; the reconciler's desired template is authoritative for
+// probes (RHOAIENG-33695).
+func syncContainerProbesFromDesired(dst *corev1.PodTemplateSpec, src *corev1.PodTemplateSpec) {
+	if dst == nil || src == nil {
+		return
+	}
+	srcByName := make(map[string]corev1.Container, len(src.Spec.Containers))
+	for _, c := range src.Spec.Containers {
+		srcByName[c.Name] = c
+	}
+	for i := range dst.Spec.Containers {
+		sc, ok := srcByName[dst.Spec.Containers[i].Name]
+		if !ok {
+			continue
+		}
+		dst.Spec.Containers[i].LivenessProbe = probeDeepCopyOrNil(sc.LivenessProbe)
+		dst.Spec.Containers[i].ReadinessProbe = probeDeepCopyOrNil(sc.ReadinessProbe)
+		dst.Spec.Containers[i].StartupProbe = probeDeepCopyOrNil(sc.StartupProbe)
+	}
+}
+
+func probeDeepCopyOrNil(p *corev1.Probe) *corev1.Probe {
+	if p == nil {
+		return nil
+	}
+	return p.DeepCopy()
+}
+
 // checkDeploymentExist checks if the deployment exists?
 func (r *DeploymentReconciler) checkDeploymentExist(client kclient.Client, deployment *appsv1.Deployment) (constants.CheckResultType, *appsv1.Deployment, error) {
 	forceStopRuntime := utils.GetForceStopRuntime(deployment)
@@ -615,27 +648,134 @@ func (r *DeploymentReconciler) Reconcile() ([]*appsv1.Deployment, error) {
 		case constants.CheckResultCreate:
 			opErr = r.client.Create(context.TODO(), deployment)
 		case constants.CheckResultUpdate:
-			// Use a full spec Update instead of strategic merge patch. Strategic merge can merge
-			// incompatible probe handler fields (e.g. httpGet retained when switching to exec),
-			// which makes the object invalid (more than one handler type).
-			desired := deployment.DeepCopy()
+			// Snapshot desired probes; env handling uses placeholders on a copy only — do not mutate
+			// the reconciler's deployment object across retries.
+			desiredProbeTemplate := deployment.Spec.Template.DeepCopy()
 
 			opErr = retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 				cur := &appsv1.Deployment{}
 				if err := r.client.Get(context.TODO(), types.NamespacedName{
-					Name:      desired.Name,
-					Namespace: desired.Namespace,
+					Name: deployment.Name, Namespace: deployment.Namespace,
 				}, cur); err != nil {
 					return err
 				}
+
+				mod := deployment.DeepCopy()
+				// Check if there are any envs to remove — placeholders on mod only.
+				for i, deploymentC := range mod.Spec.Template.Spec.Containers {
+					envs := []corev1.EnvVar{}
+					for _, origC := range cur.Spec.Template.Spec.Containers {
+						if deploymentC.Name == origC.Name {
+							envsToRemove, envsToKeep := utils.CheckEnvsToRemove(deploymentC.Env, origC.Env)
+							if len(envsToRemove) > 0 {
+								envs = append(envs, envsToKeep...)
+								envs = append(envs, envsToRemove...)
+							} else {
+								envs = deploymentC.Env
+							}
+						}
+					}
+					mod.Spec.Template.Spec.Containers[i].Env = envs
+				}
+
+				curForPatch := cur.DeepCopy()
+				curForPatch.Spec.Replicas = nil
+				curJson, err := json.Marshal(curForPatch)
+				if err != nil {
+					return err
+				}
+				mod.Spec.Replicas = nil
+
+				imagePullSecretsDesired := mod.Spec.Template.Spec.ImagePullSecrets
+				curPullSecrets := cur.Spec.Template.Spec.ImagePullSecrets
+				imagePullSecretsToRemove := []string{}
+				for _, secret := range curPullSecrets {
+					found := false
+					for _, desiredSecret := range imagePullSecretsDesired {
+						if secret.Name == desiredSecret.Name {
+							found = true
+							break
+						}
+					}
+					if !found {
+						imagePullSecretsToRemove = append(imagePullSecretsToRemove, secret.Name)
+					}
+				}
+
+				modJson, err := json.Marshal(mod)
+				if err != nil {
+					return err
+				}
+
+				patchByte, err := strategicpatch.CreateTwoWayMergePatch(curJson, modJson, appsv1.Deployment{})
+				if err != nil {
+					return err
+				}
+
+				patchByte = []byte(strings.ReplaceAll(string(patchByte), "\"value\":\""+utils.PLACEHOLDER_FOR_DELETION+"\"", "\"$patch\":\"delete\""))
+
+				if len(imagePullSecretsToRemove) > 0 {
+					patchJson := map[string]interface{}{}
+					if err = json.Unmarshal(patchByte, &patchJson); err != nil {
+						return err
+					}
+					spec, ok := patchJson["spec"].(map[string]interface{})
+					if !ok {
+						return errors.New("spec not found")
+					}
+					template, ok := spec["template"].(map[string]interface{})
+					if !ok {
+						return errors.New("template not found")
+					}
+					specTemplate, ok := template["spec"].(map[string]interface{})
+					if !ok {
+						return errors.New("template.spec not found")
+					}
+
+					ipsField, exists := specTemplate["imagePullSecrets"]
+					var imagePullSecrets []interface{}
+					if exists && ipsField != nil {
+						var ok bool
+						imagePullSecrets, ok = ipsField.([]interface{})
+						if !ok {
+							return errors.New("imagePullSecrets is not the expected type")
+						}
+					} else {
+						imagePullSecrets = []interface{}{}
+					}
+
+					for _, secret := range imagePullSecretsToRemove {
+						for _, secretMap := range imagePullSecrets {
+							if secretMap.(map[string]interface{})["name"] == secret {
+								secretMap.(map[string]interface{})["$patch"] = "delete"
+							}
+						}
+					}
+					patchJson["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["imagePullSecrets"] = imagePullSecrets
+					patchByte, err = json.Marshal(patchJson)
+					if err != nil {
+						return err
+					}
+				}
+
+				// Apply the same strategic merge locally. Patching the API with a strategic merge on
+				// probes deep-merges handlers (httpGet + exec), which fails validation (RHOAIENG-33695).
+				mergedBytes, err := strategicpatch.StrategicMergePatch(curJson, patchByte, appsv1.Deployment{})
+				if err != nil {
+					return err
+				}
+				var merged appsv1.Deployment
+				if err := json.Unmarshal(mergedBytes, &merged); err != nil {
+					return err
+				}
+
 				updated := cur.DeepCopy()
-				updated.Labels = desired.Labels
-				updated.Annotations = desired.Annotations
-				newSpec := desired.Spec.DeepCopy()
-				// Match prior patch behavior: do not change replica count via this reconcile path
-				// (diff ignores Replicas; HPA or other controllers own the live value).
-				newSpec.Replicas = cur.Spec.Replicas
-				updated.Spec = *newSpec
+				updated.Labels = deployment.Labels
+				updated.Annotations = deployment.Annotations
+				updated.Spec = merged.Spec
+				updated.Spec.Replicas = cur.Spec.Replicas
+				syncContainerProbesFromDesired(&updated.Spec.Template, desiredProbeTemplate)
+
 				return r.client.Update(context.TODO(), updated)
 			})
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_merge_update_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_merge_update_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func predictorPodSpecWithContainerEnvs(envs []corev1.EnvVar) *corev1.PodSpec {
+	spec := predictorPodSpecWithLivenessHTTPGet()
+	spec.Containers[0].Env = envs
+	return spec
+}
+
+func predictorPodSpecWithImagePullSecrets(secrets []corev1.LocalObjectReference) *corev1.PodSpec {
+	spec := predictorPodSpecWithLivenessHTTPGet()
+	spec.ImagePullSecrets = secrets
+	return spec
+}
+
+func envVarNames(envs []corev1.EnvVar) []string {
+	names := make([]string, 0, len(envs))
+	for _, e := range envs {
+		names = append(names, e.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func imagePullSecretNames(secrets []corev1.LocalObjectReference) []string {
+	names := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		names = append(names, s.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// TestDeploymentReconciler_Reconcile_removesContainerEnvVars verifies the two-way merge + Update path
+// removes env vars that are no longer in desired (not a blind desired-spec replace).
+func TestDeploymentReconciler_Reconcile_removesContainerEnvVars(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	const isvc = "env-reconcile"
+	meta := rawDeploymentComponentMeta(isvc)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	depInitial, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithContainerEnvs([]corev1.EnvVar{
+		{Name: "KEEP_ME", Value: "v1"},
+		{Name: "REMOVE_ME", Value: "gone"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment: %v", err)
+	}
+
+	rec := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depInitial.DeepCopy()},
+	}
+	if _, err := rec.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (create): %v", err)
+	}
+
+	depUpdated, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithContainerEnvs([]corev1.EnvVar{
+		{Name: "KEEP_ME", Value: "v1"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment (update): %v", err)
+	}
+
+	rec2 := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depUpdated.DeepCopy()},
+	}
+	if _, err := rec2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (update): %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cli.Get(context.Background(), types.NamespacedName{
+		Namespace: depUpdated.Namespace,
+		Name:      depUpdated.Name,
+	}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	c := containerByName(&got.Spec.Template, constants.InferenceServiceContainerName)
+	if c == nil {
+		t.Fatal("kserve-container not found")
+	}
+	gotNames := envVarNames(c.Env)
+	wantNames := []string{"KEEP_ME"}
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("env names: got %v, want %v (full env: %#v)", gotNames, wantNames, c.Env)
+	}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Fatalf("env names: got %v, want %v", gotNames, wantNames)
+		}
+	}
+}
+
+// TestDeploymentReconciler_Reconcile_updatesContainerEnvValue verifies an env value change is applied
+// through merge + Update, not only removals.
+func TestDeploymentReconciler_Reconcile_updatesContainerEnvValue(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	const isvc = "env-value-reconcile"
+	meta := rawDeploymentComponentMeta(isvc)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	depInitial, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithContainerEnvs([]corev1.EnvVar{
+		{Name: "MODEL_ID", Value: "old"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment: %v", err)
+	}
+
+	rec := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depInitial.DeepCopy()},
+	}
+	if _, err := rec.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (create): %v", err)
+	}
+
+	depUpdated, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithContainerEnvs([]corev1.EnvVar{
+		{Name: "MODEL_ID", Value: "new"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment (update): %v", err)
+	}
+
+	rec2 := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depUpdated.DeepCopy()},
+	}
+	if _, err := rec2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (update): %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cli.Get(context.Background(), types.NamespacedName{
+		Namespace: depUpdated.Namespace,
+		Name:      depUpdated.Name,
+	}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	c := containerByName(&got.Spec.Template, constants.InferenceServiceContainerName)
+	if c == nil {
+		t.Fatal("kserve-container not found")
+	}
+	var modelID string
+	for _, e := range c.Env {
+		if e.Name == "MODEL_ID" {
+			modelID = e.Value
+			break
+		}
+	}
+	if modelID != "new" {
+		t.Fatalf("MODEL_ID value: got %q, want %q (env: %#v)", modelID, "new", c.Env)
+	}
+}
+
+// TestDeploymentReconciler_Reconcile_updatesImagePullSecrets verifies imagePullSecrets removed from
+// desired are dropped on the live Deployment after merge + Update.
+func TestDeploymentReconciler_Reconcile_updatesImagePullSecrets(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+	const isvc = "pull-secret-reconcile"
+	meta := rawDeploymentComponentMeta(isvc)
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	depInitial, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithImagePullSecrets([]corev1.LocalObjectReference{
+		{Name: "old-pull-secret"},
+		{Name: "shared-pull-secret"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment: %v", err)
+	}
+
+	rec := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depInitial.DeepCopy()},
+	}
+	if _, err := rec.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (create): %v", err)
+	}
+
+	depUpdated, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, predictorPodSpecWithImagePullSecrets([]corev1.LocalObjectReference{
+		{Name: "new-pull-secret"},
+		{Name: "shared-pull-secret"},
+	}))
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment (update): %v", err)
+	}
+
+	rec2 := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depUpdated.DeepCopy()},
+	}
+	if _, err := rec2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (update): %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cli.Get(context.Background(), types.NamespacedName{
+		Namespace: depUpdated.Namespace,
+		Name:      depUpdated.Name,
+	}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	gotNames := imagePullSecretNames(got.Spec.Template.Spec.ImagePullSecrets)
+	wantNames := []string{"new-pull-secret", "shared-pull-secret"}
+	if len(gotNames) != len(wantNames) {
+		t.Fatalf("imagePullSecrets: got %v, want %v", gotNames, wantNames)
+	}
+	for i := range wantNames {
+		if gotNames[i] != wantNames[i] {
+			t.Fatalf("imagePullSecrets: got %v, want %v", gotNames, wantNames)
+		}
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_probe_update_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_probe_update_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The KServe Authors.
+Copyright 2026 The KServe Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_probe_update_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/deployment_reconciler_probe_update_test.go
@@ -1,0 +1,239 @@
+/*
+Copyright 2024 The KServe Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
+	"github.com/kserve/kserve/pkg/constants"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func predictorPodSpecWithLivenessHTTPGet() *corev1.PodSpec {
+	return &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  constants.InferenceServiceContainerName,
+			Image: "docker.io/kserve/sklearnserver:v0.15.0",
+			Args:  []string{"--model_name=probe-update", "--http_port=8080"},
+			Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					HTTPGet: &corev1.HTTPGetAction{
+						Path:   "/v2/health/live",
+						Port:   intstr.FromString("http"),
+						Scheme: corev1.URISchemeHTTP,
+					},
+				},
+				TimeoutSeconds: 5,
+				PeriodSeconds:  30,
+			},
+		}},
+	}
+}
+
+func predictorPodSpecWithLivenessExec() *corev1.PodSpec {
+	return &corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:  constants.InferenceServiceContainerName,
+			Image: "docker.io/kserve/sklearnserver:v0.15.0",
+			Args:  []string{"--model_name=probe-update", "--http_port=8080"},
+			Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080, Protocol: corev1.ProtocolTCP}},
+			LivenessProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "true"},
+					},
+				},
+				InitialDelaySeconds: 10,
+				TimeoutSeconds:      10,
+				PeriodSeconds:       30,
+				FailureThreshold:    3,
+			},
+		}},
+	}
+}
+
+func rawDeploymentComponentMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Name:      name + "-predictor",
+		Namespace: "default",
+		Labels: map[string]string{
+			constants.DeploymentMode: string(constants.RawDeployment),
+		},
+	}
+}
+
+// TestSyncContainerProbesFromDesired_replacesProbes documents RHOAIENG-33695: a bad merge can leave
+// both httpGet and exec set; desired template must win for each probe field.
+func TestSyncContainerProbesFromDesired_replacesProbes(t *testing.T) {
+	dstTemplate := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: constants.InferenceServiceContainerName,
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/v2/health/live", Port: intstr.FromString("http")},
+						Exec:    &corev1.ExecAction{Command: []string{"should-not-remain"}},
+					},
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/old", Port: intstr.FromString("http")},
+					},
+				},
+			}},
+		},
+	}
+	srcTemplate := &corev1.PodTemplateSpec{
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: constants.InferenceServiceContainerName,
+				LivenessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						Exec: &corev1.ExecAction{Command: []string{"/bin/sh", "-c", "true"}},
+					},
+					InitialDelaySeconds: 10,
+				},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/v2/health/ready", Port: intstr.FromString("http")},
+					},
+				},
+				StartupProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{Path: "/v2/health/ready", Port: intstr.FromString("http")},
+					},
+					FailureThreshold: 30,
+				},
+			}},
+		},
+	}
+
+	syncContainerProbesFromDesired(dstTemplate, srcTemplate)
+	c := &dstTemplate.Spec.Containers[0]
+	if c.LivenessProbe == nil || c.LivenessProbe.Exec == nil || len(c.LivenessProbe.Exec.Command) == 0 {
+		t.Fatalf("expected exec liveness, got %#v", c.LivenessProbe)
+	}
+	if c.LivenessProbe.HTTPGet != nil {
+		t.Fatalf("expected httpGet cleared on liveness, got %#v", c.LivenessProbe.HTTPGet)
+	}
+	if c.ReadinessProbe == nil || c.ReadinessProbe.HTTPGet == nil || c.ReadinessProbe.HTTPGet.Path != "/v2/health/ready" {
+		t.Fatalf("expected readiness from desired, got %#v", c.ReadinessProbe)
+	}
+	if c.StartupProbe == nil || c.StartupProbe.FailureThreshold != 30 {
+		t.Fatalf("expected startup from desired, got %#v", c.StartupProbe)
+	}
+}
+
+// TestDeploymentReconciler_Reconcile_updatesLivenessProbeBetweenHandlers exercises the CheckResultUpdate
+// path so liveness can switch between httpGet and exec without an invalid dual-handler Pod spec
+// (regression guard for RHOAIENG-33695).
+func TestDeploymentReconciler_Reconcile_updatesLivenessProbeBetweenHandlers(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("AddToScheme: %v", err)
+	}
+
+	const isvc = "probe-reconcile"
+	meta := rawDeploymentComponentMeta(isvc)
+
+	podHTTP := predictorPodSpecWithLivenessHTTPGet()
+	depHTTP, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, podHTTP)
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment(http): %v", err)
+	}
+
+	cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	rec := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depHTTP.DeepCopy()},
+	}
+	if _, err := rec.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (create): %v", err)
+	}
+
+	podExec := predictorPodSpecWithLivenessExec()
+	depExec, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, podExec)
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment(exec): %v", err)
+	}
+
+	rec2 := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depExec.DeepCopy()},
+	}
+	if _, err := rec2.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (update to exec): %v", err)
+	}
+
+	var got appsv1.Deployment
+	if err := cli.Get(context.Background(), types.NamespacedName{
+		Namespace: depExec.Namespace,
+		Name:      depExec.Name,
+	}, &got); err != nil {
+		t.Fatalf("Get after exec update: %v", err)
+	}
+	live := containerByName(&got.Spec.Template, constants.InferenceServiceContainerName).LivenessProbe
+	if live == nil || live.Exec == nil || live.HTTPGet != nil {
+		t.Fatalf("expected single-handler exec liveness after update, got %#v", live)
+	}
+
+	podHTTP2 := predictorPodSpecWithLivenessHTTPGet()
+	depHTTP2, err := createRawDefaultDeployment(meta, &v1beta1.ComponentExtensionSpec{}, podHTTP2)
+	if err != nil {
+		t.Fatalf("createRawDefaultDeployment(http2): %v", err)
+	}
+	rec3 := &DeploymentReconciler{
+		client:         cli,
+		scheme:         scheme,
+		DeploymentList: []*appsv1.Deployment{depHTTP2.DeepCopy()},
+	}
+	if _, err := rec3.Reconcile(); err != nil {
+		t.Fatalf("Reconcile (update back to httpGet): %v", err)
+	}
+	if err := cli.Get(context.Background(), types.NamespacedName{
+		Namespace: depHTTP2.Namespace,
+		Name:      depHTTP2.Name,
+	}, &got); err != nil {
+		t.Fatalf("Get after httpGet update: %v", err)
+	}
+	live = containerByName(&got.Spec.Template, constants.InferenceServiceContainerName).LivenessProbe
+	if live == nil || live.HTTPGet == nil || live.Exec != nil {
+		t.Fatalf("expected single-handler httpGet liveness after second update, got %#v", live)
+	}
+}
+
+func containerByName(template *corev1.PodTemplateSpec, name string) *corev1.Container {
+	for i := range template.Spec.Containers {
+		if template.Spec.Containers[i].Name == name {
+			return &template.Spec.Containers[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
([RHOAIENG-33695](https://redhat.atlassian.net/browse/RHOAIENG-33695))

## Summary
RawDeployment: Stop applying Deployment changes with a server-side strategic merge patch, which could leave two probe handlers on livenessProbe (invalid API object). Compute the same merge locally, then Update with a coherent spec; keep existing env / imagePullSecrets strategic-merge list behavior.
InferenceService: Fix stale resourceVersion on status updates and add RetryOnConflict so status writes do not fail under webhook / concurrent updates.

## Problem
Deployments (RawDeployment)
When the ServingRuntime changed the predictor liveness probe from httpGet to exec, reconciliation could fail with an error equivalent to:

`livenessProbe.httpGet: Forbidden: may not specify more than 1 handler type`

The predictor path already produced a valid desired pod (only exec). The failure happened when persisting the Deployment.

InferenceService status
After a successful reconcile, status updates could fail with:

`the object has been modified; please apply your changes to the latest version and try again`
because status was applied to an object whose metadata did not match the latest apiserver revision.

## Root cause
Deployment: client.Patch(..., StrategicMergePatchType) causes the apiserver to deep-merge Probe / ProbeHandler. That can retain the old handler while adding the new one. Editing the patch JSON client-side does not prevent that second merge on the server.

Status: updateStatus performed a fresh Get for comparison but called Status().Update(desiredService) using the InferenceService instance from the start of Reconcile, whose resourceVersion could be older than the object returned by the later Get (e.g. mutating webhooks or concurrent writers).

## Solution
deployment_reconciler.go ([RHOAIENG-33695](https://redhat.atlassian.net/browse/RHOAIENG-33695))
For CheckResultUpdate:

- Wrap in retry.RetryOnConflict; each attempt Gets the live Deployment (cur).
- Build mod from deployment.DeepCopy() and run the existing env removal / placeholder logic against cur (do not mutate the shared reconciler deployment across retries).
- Snapshot desiredProbeTemplate for authoritative probes.
- Marshal cur and mod with Spec.Replicas = nil on both (unchanged: avoid driving replicas here; HPA owns the live value).
- CreateTwoWayMergePatch(curJson, modJson, appsv1.Deployment{}), then the same placeholder → $patch: delete substitution and optional imagePullSecrets JSON $patch: delete edits as before.
- Apply the patch only locally: StrategicMergePatch(curJson, patchByte, appsv1.Deployment{}), unmarshal to typed Deployment (merged).
- updated := cur.DeepCopy(), copy labels/annotations from desired, updated.Spec = merged.Spec, updated.Spec.Replicas = cur.Spec.Replicas, then syncContainerProbesFromDesired so liveness / readiness / startup match the reconciler’s desired template.
- client.Update(ctx, updated).
- Wrap updateStatus in retry.RetryOnConflict.
- On each attempt, Get the latest InferenceService, compare status; if an update is needed, copy desiredService.Status onto that fresh object and Status().Update it so resourceVersion matches the apiserver.

## Testing

- `go test ./pkg/controller/v1beta1/inferenceservice/reconcilers/deployment/...`
- Manual: repro in this directory — apply httpGet liveness SR, then exec SR,
  bump ISVC to force reconcile; Deployment should roll with exec-only liveness
  and no API validation error (see “Log excerpt” below).
