### PR TITLE
build: add distro build tag to controller Konflux Dockerfile

### DIFF
--- a/Dockerfiles/controller.Dockerfile.konflux
+++ b/Dockerfiles/controller.Dockerfile.konflux
@@ -4,6 +4,7 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.
 ARG TARGETOS TARGETARCH
+ARG GOTAGS="distro"
 RUN echo "GOOS=${TARGETOS} GOARCH=${TARGETARCH}"
 
 # Copy in the go src
@@ -18,7 +19,7 @@ COPY pkg/    pkg/
 
 # Build
 USER root
-RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=-mod=mod GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -a -o manager ./cmd/manager
+RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOFLAGS=-mod=mod GOEXPERIMENT=strictfipsruntime go build -tags "${GOTAGS},strictfipsruntime" -a -o manager ./cmd/manager
 
 # Use distroless as minimal base image to package the manager binary
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller Konflux Dockerfile was building without the `distro` build tag, silently excluding all `//go:build distro` gated code from the binary - including the OpenShift Route scheme registration. This caused the InferenceGraph controller to crash on startup when attempting to watch `v1.Route` resources.

The `llmisvc-controller.Dockerfile.konflux` already has this correct with `ARG GOTAGS="distro"` combined with `strictfipsruntime`. This PR applies the same pattern to the controller Dockerfile.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] `llmisvc-controller.Dockerfile.konflux` already follows this pattern as the canonical reference

**Special notes for your reviewer**:

Same class of bug fixed for the main controller in opendatahub-io/kserve#1329. The `llmisvc` Dockerfile had `ARG GOTAGS="distro"` from the start; the controller Dockerfile was overlooked.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
NONE
```