### PR TITLE
[RHOAIENG-54247] CVE-2026-30922: pin pyasn1>=0.6.3

### DIFF
--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4203,13 +4203,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]
@@ -7032,4 +7032,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "fe14ca68bfb10fecdad64751ba8390f64b6005a737369e9facf724e2c22ae939"
+content-hash = "f098fac6810e44cb09206fecf92fcfb669a80a7c6788db94036fb1ae067d194d"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -64,6 +64,9 @@ aiohttp = ">=3.13.3"
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
 # Pinning because it is a transitive dependency.
 PyJWT = ">=2.12.0"
+# CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion
+# Pinning because it is a transitive dependency.
+pyasn1 = ">=0.6.3"
 
 # Storage dependencies. They can be opted into by apps.
 requests = { version = "^2.32.2", optional = true }

--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -793,13 +793,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.1"
+version = "0.6.3"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629"},
-    {file = "pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034"},
+    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
+    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
 ]
 
 [[package]]
@@ -1039,4 +1039,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "588a73dbd7ba424da98b954eb8544f0f4a48757ef3e4b7190b07e560629457a7"
+content-hash = "f99929601a359344cb01cc1d0297699475289a48ac951073be6a2af6baa8ac33"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -31,6 +31,9 @@ huggingface-hub = { version = "^0.30.0", extras = ["hf-transfer"]}
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
 # Pinning because it is a transitive dependency.
 PyJWT = {version = ">=2.12.0"}
+# CVE-2026-30922 pyasn1 Vulnerable to Denial of Service via Unbounded Recursion
+# Pinning because it is a transitive dependency.
+pyasn1 = {version = ">=0.6.3"}
 
 
 #[tool.poetry-version-plugin]


### PR DESCRIPTION
## Summary
- Pin `pyasn1>=0.6.3` as a transitive dependency in `python/kserve/pyproject.toml` and `python/storage/pyproject.toml`
- Fixes CVE-2026-30922: pyasn1 Vulnerable to Denial of Service via Unbounded Recursion

**JIRA:** https://issues.redhat.com/browse/RHOAIENG-54247

**Upstream PR:** https://github.com/opendatahub-io/kserve/pull/1409