### PR TITLE
RHOAIENG-58364: Use v1alpha1 for LLMInferenceServiceConfig to allow upgrades

### DIFF
--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-template

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-decode-worker-data-parallel

--- a/config/llmisvcconfig/config-llm-prefill-template.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-template

--- a/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-prefill-worker-data-parallel.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-prefill-worker-data-parallel

--- a/config/llmisvcconfig/config-llm-router-route.yaml
+++ b/config/llmisvcconfig/config-llm-router-route.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-router-route

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-scheduler

--- a/config/llmisvcconfig/config-llm-template.yaml
+++ b/config/llmisvcconfig/config-llm-template.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-template

--- a/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-worker-data-parallel.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kserve.io/v1alpha2
+apiVersion: serving.kserve.io/v1alpha1
 kind: LLMInferenceServiceConfig
 metadata:
   name: kserve-config-llm-worker-data-parallel


### PR DESCRIPTION
The operator applies webhooks, then LLMInferenceServiceConfig before applying the webhook deployment, which causes it to never recover from:
```
Failed to call webhook: the server could not find the requested resource
```

