### PR TITLE
Add mandatory RHOAI Dockerfile labels for odh-kserve-localmodel-controller

### DIFF
--- a/Dockerfiles/localmodel.Dockerfile.konflux
+++ b/Dockerfiles/localmodel.Dockerfile.konflux
@@ -48,10 +48,10 @@ USER 1000:1000
 ENTRYPOINT ["/manager"]
 
 LABEL com.redhat.component="odh-kserve-localmodel-controller-rhel9" \
-      name="managed-open-data-hub/odh-kserve-localmodel-controller-rhel9" \
+      name="rhoai/odh-kserve-localmodel-controller-rhel9" \
       description="odh-kserve-localmodel-controller" \
       summary="odh-kserve-localmodel-controller" \
-      maintainer="['managed-open-data-hub@redhat.com']" \
+      maintainer="odh-kserve-localmodel-controller" \
       io.openshift.expose-services="" \
       io.k8s.display-name="odh-kserve-localmodel-controller" \
       io.k8s.description="odh-kserve-localmodel-controller" \


### PR DESCRIPTION
Adds the seven mandatory RHOAI OCI labels to `Dockerfiles/localmodel.Dockerfile.konflux`.

## Labels added / corrected

| Label | Value |
|-------|-------|
| `name` | `rhoai/odh-kserve-localmodel-controller-rhel9` |
| `com.redhat.component` | `odh-kserve-localmodel-controller-rhel9` |
| `summary` | `odh-kserve-localmodel-controller` |
| `description` | `odh-kserve-localmodel-controller` |
| `maintainer` | `odh-kserve-localmodel-controller` |
| `io.k8s.display-name` | `odh-kserve-localmodel-controller` |
| `io.k8s.description` | `odh-kserve-localmodel-controller` |

**File changed:** `Dockerfiles/localmodel.Dockerfile.konflux`
**Component repo:** https://github.com/red-hat-data-services/kserve
**Jira:** https://redhat.atlassian.net/browse/RHOAIENG-56375