### PR TITLE
fix: standardize image references in Konflux container files

### DIFF
--- a/Dockerfiles/localmodel-agent.Dockerfile.konflux
+++ b/Dockerfiles/localmodel-agent.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS deps
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS deps
 # distro: UBI go-toolset does not add GOPATH/bin to PATH
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
@@ -36,7 +36,7 @@ COPY pkg/    pkg/
 COPY LICENSE LICENSE
 
 # Copy the controller-manager into a thin image
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 RUN microdnf install -y --disablerepo=* --enablerepo=ubi-9-baseos-rpms shadow-utils && \
     microdnf clean all && \

--- a/Dockerfiles/localmodel.Dockerfile.konflux
+++ b/Dockerfiles/localmodel.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi9/go-toolset@sha256:d637b9dfccb16623f19b95c43fe5a65b20b722e62753c4445c5d02f9e40b807d AS deps
+FROM registry.redhat.io/ubi9/go-toolset:1.25 AS deps
 # distro: UBI go-toolset does not add GOPATH/bin to PATH
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
@@ -35,7 +35,7 @@ COPY pkg/    pkg/
 COPY LICENSE LICENSE
 
 # Copy the controller-manager into a thin image
-FROM registry.redhat.io/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea
+FROM registry.redhat.io/ubi9/ubi-minimal:latest
 
 RUN microdnf install -y --disablerepo=* --enablerepo=ubi-9-baseos-rpms shadow-utils && \
     microdnf clean all && \


### PR DESCRIPTION
**What this PR does / why we need it**:

Add both SHA and tags to image references. Some images were updated to
new versions.

This is related to opendatahub-io/kserve#1443

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Related to https://redhat.atlassian.net/browse/RHOAIENG-54583


**Feature/Issue validation/testing**:

TODO
