### PR TITLE
RHOAIENG-60525: [rhoai-3.3] fix(llmisvc): always set status.URL with a discovered address

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_types.go
@@ -284,7 +284,10 @@ type UntypedObjectReference struct {
 
 // LLMInferenceServiceStatus defines the observed state of LLMInferenceService.
 type LLMInferenceServiceStatus struct {
-	// URL of the publicly exposed service.
+	// URL is the primary address for accessing the service.
+	// It is set to an external (public) address when available, otherwise
+	// it is promoted from the first discovered address (which may be
+	// cluster-local or private) for easy discovery.
 	// +optional
 	URL *apis.URL `json:"url,omitempty"`
 

--- a/pkg/controller/llmisvc/router.go
+++ b/pkg/controller/llmisvc/router.go
@@ -285,7 +285,15 @@ func (r *LLMInferenceServiceReconciler) updateRoutingStatus(ctx context.Context,
 	externalURLs := FilterExternalURLs(urls)
 	if len(externalURLs) == 0 {
 		logger.Info("no public URL discovered")
-		llmSvc.Status.URL = nil
+		if len(urls) > 0 {
+			// Promote first address to top-level status.URL as some "cluster external" addresses are technically within
+			// "virtual private networks" and we cannot detect that from just IPs. Even if it's a cluster-local URL, the
+			// status URL is just for discovery and easy access, and it's not a problem to have here while we prioritize
+			// external addresses.
+			llmSvc.Status.URL = urls[0]
+		} else {
+			llmSvc.Status.URL = nil
+		}
 	} else {
 		llmSvc.Status.URL = externalURLs[0]
 	}


### PR DESCRIPTION
Upstream: https://github.com/kserve/kserve/commit/b94e9077bd363acba979b1678eb49b2d65b840e2

