### PR TITLE
RHOAIENG-58347: [rhoai-3.4] feat(llmisvc): add migration logic for llm-d v0.6 components upgrade

### DIFF
--- a/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
+++ b/charts/kserve-runtime-configs/files/llmisvcconfigs/resources.yaml
@@ -206,7 +206,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -516,7 +516,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -1599,6 +1599,8 @@ metadata:
 spec:
   router:
     scheduler:
+      annotations:
+        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:

--- a/config/llmisvcconfig/config-llm-decode-template.yaml
+++ b/config/llmisvcconfig/config-llm-decode-template.yaml
@@ -241,7 +241,7 @@ spec:
           - "/app/pd-sidecar"
           - "--port=8000"
           - "--vllm-port=8001"
-          - "--connector=nixlv2"
+          - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
           - "--pool-group=inference.networking.x-k8s.io"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'

--- a/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
+++ b/config/llmisvcconfig/config-llm-decode-worker-data-parallel.yaml
@@ -45,7 +45,7 @@ spec:
           - "/app/pd-sidecar"
           - "--port=8000"
           - "--vllm-port=8001"
-          - "--connector=nixlv2"
+          - "--kv-connector=nixlv2"
           - "--enable-ssrf-protection=true"
           - "--pool-group=inference.networking.x-k8s.io"
           - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{- end }}'

--- a/config/llmisvcconfig/config-llm-scheduler.yaml
+++ b/config/llmisvcconfig/config-llm-scheduler.yaml
@@ -22,6 +22,8 @@ spec:
               kserve.io/component: workload
           targetPorts:
             - number: 8000
+      annotations:
+        "app.kubernetes.io/version": "0.7.0"
       template:
         containers:
           - name: main

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.2
 	github.com/aws/aws-sdk-go v1.55.6
 	github.com/cloudevents/sdk-go/v2 v2.16.0
+	github.com/coreos/go-semver v0.3.1
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/go-logr/logr v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,8 @@ github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
 github.com/containerd/errdefs/pkg v0.3.0/go.mod h1:NJw6s9HwNuRhnjJhM7pylWwMyAkmCQvQ4GpJHEqRLVk=
+github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=
+github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03VsM8rvUec=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-knative-mode-full-install-with-manifests.sh
@@ -2662,7 +2662,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2972,7 +2972,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -4055,6 +4055,8 @@ metadata:
 spec:
   router:
     scheduler:
+      annotations:
+        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:

--- a/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
+++ b/hack/setup/quick-install/kserve-standard-mode-full-install-with-manifests.sh
@@ -2248,7 +2248,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -2558,7 +2558,7 @@ spec:
       - /app/pd-sidecar
       - --port=8000
       - --vllm-port=8001
-      - --connector=nixlv2
+      - --kv-connector=nixlv2
       - --enable-ssrf-protection=true
       - --pool-group=inference.networking.x-k8s.io
       - '{{ if .GlobalConfig.EnableTLS }}--secure-proxy=true{{else}}--secure-proxy=false{{-
@@ -3641,6 +3641,8 @@ metadata:
 spec:
   router:
     scheduler:
+      annotations:
+        app.kubernetes.io/version: 0.7.0
       pool:
         spec:
           endpointPickerRef:

--- a/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_presets_test.go
@@ -99,7 +99,7 @@ func TestPresetFiles(t *testing.T) {
 										"/app/pd-sidecar",
 										"--port=8000",
 										"--vllm-port=8001",
-										"--connector=nixlv2",
+										"--kv-connector=nixlv2",
 										"--enable-ssrf-protection=true",
 										"--pool-group=inference.networking.x-k8s.io",
 										"--secure-proxy=false",

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -433,14 +433,14 @@ schedulingProfiles:
 				}, expectedDeployment)
 			}).WithContext(ctx).Should(Succeed())
 
-			// Verify P/D config (should contain prefill-filter, decode-filter, pd-profile-handler, etc.)
+			// Verify P/D config (should contain prefill-filter, decode-filter, disagg-profile-handler, etc.)
 			configText, found := getSchedulerConfigText(expectedDeployment)
 			Expect(found).To(BeTrue(), "Expected P/D config in scheduler deployment")
-			// P/D config should contain these plugins
-			Expect(configText).To(ContainSubstring("prefill-header-handler"))
+			// P/D config should contain these plugins (using new v0.7.0 names)
+			Expect(configText).To(ContainSubstring("disagg-headers-handler"))
 			Expect(configText).To(ContainSubstring("prefill-filter"))
 			Expect(configText).To(ContainSubstring("decode-filter"))
-			Expect(configText).To(ContainSubstring("pd-profile-handler"))
+			Expect(configText).To(ContainSubstring("disagg-profile-handler"))
 			Expect(configText).To(ContainSubstring("name: prefill"))
 			Expect(configText).To(ContainSubstring("name: decode"))
 		})

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -25,7 +25,9 @@ import (
 	"path"
 	"slices"
 	"sort"
+	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -54,6 +56,7 @@ const (
 
 	precisePrefixCacheScorerPlugin = "precise-prefix-cache-scorer"
 	prefixCacheScorerPlugin        = "prefix-cache-scorer"
+	coreMetricsExtractorPlugin     = "core-metrics-extractor"
 	udsTokenizerBaseModelName      = "base"
 	udsTokenizerSocketFile         = "/tmp/tokenizer/tokenizer-uds.socket" //nolint:gosec // G101: not a credential, UDS socket path
 )
@@ -373,6 +376,8 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 		},
 	}
 
+	r.propagateSchedulerMetadata(llmSvc, d)
+
 	if llmSvc.Spec.Router != nil && llmSvc.Spec.Router.Scheduler != nil && llmSvc.Spec.Router.Scheduler.Template != nil {
 		curr := &appsv1.Deployment{}
 		if err := r.Get(ctx, client.ObjectKeyFromObject(d), curr); err != nil && !apierrors.IsNotFound(err) {
@@ -451,9 +456,14 @@ func (r *LLMISVCReconciler) expectedSchedulerDeployment(ctx context.Context, llm
 				return d, fmt.Errorf("failed to mutate scheduler config: %w", err)
 			}
 		}
-	}
 
-	r.propagateSchedulerMetadata(llmSvc, d)
+		// v0.7.0 migrations: version-gated (>= 0.7.0) because the v0.6 binary
+		// does not recognize the new plugin names. The v0.7 binary deprecates
+		// the old names but still accepts them.
+		if err := schedulerTransform(ctx, d); err != nil {
+			return d, fmt.Errorf("failed to apply v0.7.0 scheduler migrations: %w", err)
+		}
+	}
 
 	log.FromContext(ctx).V(2).Info("Expected router scheduler deployment", "deployment", d)
 
@@ -484,16 +494,17 @@ func schedulerConfigText(llmSvc *v1alpha2.LLMInferenceService) string {
 apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
-- type: prefill-header-handler
+- type: disagg-headers-handler
 - type: prefill-filter
 - type: decode-filter
 - type: queue-scorer
 - type: prefix-cache-scorer
 - type: max-score-picker
 - type: always-disagg-pd-decider
-- type: pd-profile-handler
+- type: disagg-profile-handler
   parameters:
-    deciderPluginName: always-disagg-pd-decider
+    deciders:
+      prefill: always-disagg-pd-decider
 schedulingProfiles:
 - name: prefill
   plugins:
@@ -754,8 +765,14 @@ func (r *LLMISVCReconciler) propagateSchedulerDeploymentStatus(ctx context.Conte
 	return nil
 }
 
+// mutateSchedulerConfigFunc operates on the parsed EndpointPickerConfig YAML.
+// Each function receives the deserialized config as an Unstructured object and
+// may mutate it in place.
 type mutateSchedulerConfigFunc func(ctx context.Context, u *unstructured.Unstructured) error
 
+// mutateSchedulerConfig finds the --config-text arg, unmarshals the YAML once,
+// applies all opts sequentially, then marshals back. This ensures a single
+// unmarshal/marshal round-trip regardless of how many mutations are batched.
 func mutateSchedulerConfig(ctx context.Context, d *appsv1.Deployment, opts ...mutateSchedulerConfigFunc) error {
 	schedulerContainer := utils.GetContainerWithName(&d.Spec.Template.Spec, "main")
 	if schedulerContainer == nil {
@@ -910,6 +927,387 @@ func WithMigrateBlockSizeToBlockSizeTokens(ctx context.Context, u *unstructured.
 	}
 
 	return nil
+}
+
+// WithRenamePlugin returns a mutateSchedulerConfigFunc that renames a plugin
+// type in the plugins array and updates matching pluginRef entries in
+// schedulingProfiles. This handles plugin renames across scheduler versions.
+func WithRenamePlugin(oldType, newType string) mutateSchedulerConfigFunc {
+	return func(_ context.Context, u *unstructured.Unstructured) error {
+		val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil || !found {
+			return err
+		}
+		plugins, ok := val.([]interface{})
+		if !ok {
+			return nil
+		}
+
+		for _, plugin := range plugins {
+			pluginMap, ok := plugin.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if pluginMap["type"] == oldType {
+				pluginMap["type"] = newType
+			}
+			if pluginMap["name"] == oldType {
+				pluginMap["name"] = newType
+			}
+		}
+
+		profiles, found, err := unstructured.NestedFieldNoCopy(u.Object, "schedulingProfiles")
+		if err != nil || !found {
+			return err
+		}
+		profileList, ok := profiles.([]interface{})
+		if !ok {
+			return nil
+		}
+		for _, profile := range profileList {
+			profileMap, ok := profile.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			pluginRefs, found, _ := unstructured.NestedFieldNoCopy(profileMap, "plugins")
+			if !found {
+				continue
+			}
+			refList, ok := pluginRefs.([]interface{})
+			if !ok {
+				continue
+			}
+			for _, ref := range refList {
+				refMap, ok := ref.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if refMap["pluginRef"] == oldType {
+					refMap["pluginRef"] = newType
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+// WithMigrateDisaggProfileParams migrates the disagg-profile-handler (formerly
+// pd-profile-handler) from the old flat deciderPluginName parameter to the new
+// deciders map structure introduced in llm-d-inference-scheduler v0.7.0.
+func WithMigrateDisaggProfileParams(ctx context.Context, u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	needDeciderPluginEntry := false
+
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pluginType, _ := pluginMap["type"].(string)
+		if pluginType != "disagg-profile-handler" && pluginType != "pd-profile-handler" {
+			continue
+		}
+
+		// Already migrated -- nothing to do.
+		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "deciders"); exists {
+			log.FromContext(ctx).V(2).Info("deciders map already present, skipping disagg-profile-handler migration")
+			continue
+		}
+
+		// Path A: deciderPluginName → deciders map. Also strips threshold if co-present.
+		deciderName, deciderFound, err := unstructured.NestedString(pluginMap, "parameters", "deciderPluginName")
+		if err != nil {
+			return err
+		}
+		if deciderFound {
+			log.FromContext(ctx).Info("Migrating deciderPluginName to deciders map for disagg-profile-handler", "deciderPluginName", deciderName)
+			deciders := map[string]interface{}{
+				"prefill": deciderName,
+			}
+			if err := unstructured.SetNestedField(pluginMap, deciders, "parameters", "deciders"); err != nil {
+				return err
+			}
+			unstructured.RemoveNestedField(pluginMap, "parameters", "deciderPluginName")
+			unstructured.RemoveNestedField(pluginMap, "parameters", "threshold")
+			continue
+		}
+
+		// Path B: threshold:0 (no deciderPluginName) → always-disagg-pd-decider.
+		// threshold:0 means "always disaggregate", which maps directly to the
+		// always-disagg-pd-decider plugin.
+		thresholdVal, thresholdFound, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "threshold")
+		if !thresholdFound {
+			continue
+		}
+		if fmt.Sprintf("%v", thresholdVal) != "0" {
+			continue
+		}
+		log.FromContext(ctx).Info("Migrating threshold:0 to always-disagg-pd-decider for disagg-profile-handler")
+		deciders := map[string]interface{}{
+			"prefill": "always-disagg-pd-decider",
+		}
+		if err := unstructured.SetNestedField(pluginMap, deciders, "parameters", "deciders"); err != nil {
+			return err
+		}
+		unstructured.RemoveNestedField(pluginMap, "parameters", "threshold")
+		needDeciderPluginEntry = true
+	}
+
+	// Ensure the always-disagg-pd-decider plugin entry exists in the top-level
+	// plugins list when we migrated threshold:0 (the decider must be declared).
+	if needDeciderPluginEntry {
+		for _, p := range plugins {
+			if pm, ok := p.(map[string]interface{}); ok && pm["type"] == "always-disagg-pd-decider" {
+				return nil
+			}
+		}
+		plugins = append(plugins, map[string]interface{}{"type": "always-disagg-pd-decider"})
+		if err := unstructured.SetNestedSlice(u.Object, plugins, "plugins"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// WithRemoveHashBlockSize removes the deprecated hashBlockSize field from
+// all plugin parameters. This field was removed in llm-d-inference-scheduler v0.7.0.
+func WithRemoveHashBlockSize(_ context.Context, u *unstructured.Unstructured) error {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return err
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return nil
+	}
+
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		unstructured.RemoveNestedField(pluginMap, "parameters", "hashBlockSize")
+	}
+
+	return nil
+}
+
+// schedulerTransform applies all v0.7.0 scheduler migrations in a single pass.
+// It reads the app.kubernetes.io/version annotation from the Deployment's pod
+// template; if the version is < 0.7.0 (or absent, which defaults to 0.0.0),
+// all migrations are skipped because the v0.6 binary would reject new names.
+//
+// Migrations applied (in order):
+//  1. extractDeprecatedMetricFlags  – strip 5 CLI flags hard-rejected by GIE v1.4.0
+//  2. withMigrateDisaggHeadersHandler – rename prefill-header-handler → disagg-headers-handler
+//  3. withMigrateDisaggProfileHandler – rename pd-profile-handler → disagg-profile-handler,
+//     migrate deciderPluginName/threshold to deciders map (skipped for non-zero threshold)
+//  4. WithRemoveHashBlockSize – drop deprecated hashBlockSize from all plugins
+//  5. withCoreMetricsExtractorPlugin – inject core-metrics-extractor with extracted flag values
+func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
+	version, ok := d.Spec.Template.Annotations["app.kubernetes.io/version"]
+	if !ok || version == "" {
+		version = "0.0.0"
+	}
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+	if v.Compare(*semver.New("0.7.0")) < 0 {
+		return nil
+	}
+
+	extracted := extractDeprecatedMetricFlags(d)
+
+	return mutateSchedulerConfig(ctx, d,
+		withMigrateDisaggHeadersHandler,
+		withMigrateDisaggProfileHandler,
+		WithRemoveHashBlockSize,
+		withCoreMetricsExtractorPlugin(extracted),
+	)
+}
+
+// withMigrateDisaggHeadersHandler renames the prefill-header-handler plugin to
+// disagg-headers-handler (v0.7.0 rename).
+func withMigrateDisaggHeadersHandler(ctx context.Context, u *unstructured.Unstructured) error {
+	return WithRenamePlugin("prefill-header-handler", "disagg-headers-handler")(ctx, u)
+}
+
+// withMigrateDisaggProfileHandler renames the pd-profile-handler plugin to
+// disagg-profile-handler and migrates its parameters from the flat
+// deciderPluginName to the new deciders map (v0.7.0 rename + restructure).
+//
+// If the profile handler has a non-zero threshold value, the entire migration
+// is skipped (no rename, no param change) because there is no clean v0.7
+// equivalent for arbitrary threshold values. The v0.7 binary still accepts
+// the old pd-profile-handler + threshold as a deprecated alias.
+func withMigrateDisaggProfileHandler(ctx context.Context, u *unstructured.Unstructured) error {
+	if hasNonZeroThreshold(u) {
+		log.FromContext(ctx).Info("Skipping disagg-profile-handler migration: non-zero threshold has no v0.7 equivalent")
+		return nil
+	}
+	for _, fn := range []mutateSchedulerConfigFunc{
+		WithRenamePlugin("pd-profile-handler", "disagg-profile-handler"),
+		WithMigrateDisaggProfileParams,
+	} {
+		if err := fn(ctx, u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// hasNonZeroThreshold returns true if the EndpointPickerConfig contains a
+// profile handler plugin with a non-zero threshold and no deciders map.
+// Such configs have no clean v0.7 equivalent; the v0.7 binary still accepts
+// them as deprecated, so we leave them untouched to avoid partial migrations.
+func hasNonZeroThreshold(u *unstructured.Unstructured) bool {
+	val, found, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+	if err != nil || !found {
+		return false
+	}
+	plugins, ok := val.([]interface{})
+	if !ok {
+		return false
+	}
+	for _, plugin := range plugins {
+		pluginMap, ok := plugin.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		pluginType, _ := pluginMap["type"].(string)
+		if pluginType != "disagg-profile-handler" && pluginType != "pd-profile-handler" {
+			continue
+		}
+		// Already migrated to deciders map -- not a legacy threshold config.
+		if _, exists, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "deciders"); exists {
+			return false
+		}
+		thresholdVal, thresholdFound, _ := unstructured.NestedFieldNoCopy(pluginMap, "parameters", "threshold")
+		if !thresholdFound {
+			return false
+		}
+		// threshold:0 is semantically "always disaggregate" and can be migrated.
+		if fmt.Sprintf("%v", thresholdVal) != "0" {
+			return true
+		}
+	}
+	return false
+}
+
+// extractDeprecatedMetricFlags strips the 5 metric CLI flags that GIE v1.4.0
+// hard-rejects at startup. Returns their values so they can be re-injected as
+// core-metrics-extractor plugin parameters in the EndpointPickerConfig YAML.
+func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
+	toRemove := map[string]bool{
+		"total-queued-requests-metric":     true,
+		"total-running-requests-metric":    true,
+		"kv-cache-usage-percentage-metric": true,
+		"lora-info-metric":                 true,
+		"cache-info-metric":                true,
+	}
+	var allExtracted map[string]string
+	for ci := range d.Spec.Template.Spec.Containers {
+		c := &d.Spec.Template.Spec.Containers[ci]
+		filtered, extracted := filterArgs(c.Args, toRemove)
+		c.Args = filtered
+		if len(extracted) > 0 {
+			allExtracted = extracted
+		}
+	}
+	return allExtracted
+}
+
+// filterArgs removes matching flags from args and returns their values.
+// It handles both --flag=value and --flag value forms.
+func filterArgs(args []string, names map[string]bool) (filtered []string, extracted map[string]string) {
+	extracted = make(map[string]string)
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		name := strings.TrimLeft(arg, "-")
+		value := ""
+		if eqIdx := strings.Index(name, "="); eqIdx != -1 {
+			value = name[eqIdx+1:]
+			name = name[:eqIdx]
+		}
+		if !names[name] {
+			filtered = append(filtered, args[i])
+			continue
+		}
+		if value == "" && i+1 < len(args) && !strings.HasPrefix(args[i+1], "-") {
+			value = args[i+1]
+			i++
+		}
+		extracted[name] = value
+	}
+	return filtered, extracted
+}
+
+// withCoreMetricsExtractorPlugin returns a mutateSchedulerConfigFunc that
+// injects the core-metrics-extractor plugin with the metric spec values
+// previously passed as CLI flags. No-op if the plugin already exists or no
+// flags were extracted.
+func withCoreMetricsExtractorPlugin(extracted map[string]string) mutateSchedulerConfigFunc {
+	argToEngineConfigField := map[string]string{
+		"total-queued-requests-metric":     "queuedRequestsSpec",
+		"total-running-requests-metric":    "runningRequestsSpec",
+		"kv-cache-usage-percentage-metric": "kvUsageSpec",
+		"lora-info-metric":                 "loraSpec",
+		"cache-info-metric":                "cacheInfoSpec",
+	}
+
+	return func(_ context.Context, u *unstructured.Unstructured) error {
+		if len(extracted) == 0 {
+			return nil
+		}
+
+		val, _, err := unstructured.NestedFieldNoCopy(u.Object, "plugins")
+		if err != nil {
+			return err
+		}
+		plugins, _ := val.([]interface{})
+
+		for _, plugin := range plugins {
+			pluginMap, ok := plugin.(map[string]interface{})
+			if ok && pluginMap["type"] == coreMetricsExtractorPlugin {
+				return nil
+			}
+		}
+
+		engineConfig := map[string]interface{}{
+			"name": "vllm",
+		}
+		for argName, fieldName := range argToEngineConfigField {
+			if v, ok := extracted[argName]; ok {
+				engineConfig[fieldName] = v
+			}
+		}
+
+		pluginEntry := map[string]interface{}{
+			"name": coreMetricsExtractorPlugin,
+			"type": coreMetricsExtractorPlugin,
+			"parameters": map[string]interface{}{
+				"engineLabelKey": "inference.networking.k8s.io/engine-type",
+				"defaultEngine":  "vllm",
+				"engineConfigs": []interface{}{
+					engineConfig,
+				},
+			},
+		}
+
+		plugins = append(plugins, pluginEntry)
+		return unstructured.SetNestedSlice(u.Object, plugins, "plugins")
+	}
 }
 
 func semanticServiceIsEqual(expected *corev1.Service, current *corev1.Service) bool {

--- a/pkg/controller/v1alpha2/llmisvc/scheduler.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler.go
@@ -544,6 +544,13 @@ schedulingProfiles:
 	}
 }
 
+// inlineConfigTextFlags lists the config-text flag variants that carry inline
+// YAML and can be rewritten by mutateSchedulerConfig. Go's flag package
+// accepts both kebab-case and camelCase, so all four forms are valid.
+var inlineConfigTextFlags = map[string]struct{}{
+	"--config-text": {}, "-config-text": {}, "--configText": {}, "-configText": {},
+}
+
 // schedulerConfigFlags lists both kebab-case and camelCase variants because
 // Go's flag package accepts either form.
 var schedulerConfigFlags = map[string]struct{}{
@@ -770,9 +777,10 @@ func (r *LLMISVCReconciler) propagateSchedulerDeploymentStatus(ctx context.Conte
 // may mutate it in place.
 type mutateSchedulerConfigFunc func(ctx context.Context, u *unstructured.Unstructured) error
 
-// mutateSchedulerConfig finds the --config-text arg, unmarshals the YAML once,
-// applies all opts sequentially, then marshals back. This ensures a single
-// unmarshal/marshal round-trip regardless of how many mutations are batched.
+// mutateSchedulerConfig finds an inline config-text arg (any of the four
+// accepted spellings), unmarshals the YAML once, applies all opts
+// sequentially, then marshals back. This ensures a single unmarshal/marshal
+// round-trip regardless of how many mutations are batched.
 func mutateSchedulerConfig(ctx context.Context, d *appsv1.Deployment, opts ...mutateSchedulerConfigFunc) error {
 	schedulerContainer := utils.GetContainerWithName(&d.Spec.Template.Spec, "main")
 	if schedulerContainer == nil {
@@ -780,7 +788,7 @@ func mutateSchedulerConfig(ctx context.Context, d *appsv1.Deployment, opts ...mu
 	}
 
 	for i := range len(schedulerContainer.Args) - 1 {
-		if schedulerContainer.Args[i] == "--config-text" || schedulerContainer.Args[i] == "-config-text" {
+		if _, ok := inlineConfigTextFlags[schedulerContainer.Args[i]]; ok {
 			u := unstructured.Unstructured{}
 			if err := yaml.Unmarshal([]byte(schedulerContainer.Args[i+1]), &u); err != nil {
 				// Config text is not a valid YAML object (e.g. a plain string from a user-provided template),
@@ -1102,12 +1110,61 @@ func WithRemoveHashBlockSize(_ context.Context, u *unstructured.Unstructured) er
 	return nil
 }
 
+// hasWritableConfigText reports whether the "main" container has an inline
+// config-text flag (any of the four accepted spellings) whose value can be
+// rewritten by mutateSchedulerConfig.
+func hasWritableConfigText(d *appsv1.Deployment) bool {
+	c := utils.GetContainerWithName(&d.Spec.Template.Spec, "main")
+	if c == nil {
+		return false
+	}
+	for i := range len(c.Args) - 1 {
+		if _, ok := inlineConfigTextFlags[c.Args[i]]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// deprecatedMetricFlagNames is the set of CLI flag names (without leading
+// dashes) that GIE v1.4.0 hard-rejects at startup.
+var deprecatedMetricFlagNames = map[string]bool{
+	"total-queued-requests-metric":     true,
+	"total-running-requests-metric":    true,
+	"kv-cache-usage-percentage-metric": true,
+	"lora-info-metric":                 true,
+	"cache-info-metric":                true,
+}
+
+// hasDeprecatedMetricFlags reports whether any container in the pod spec
+// carries one of the 5 deprecated metric CLI flags, without modifying args.
+func hasDeprecatedMetricFlags(d *appsv1.Deployment) bool {
+	for ci := range d.Spec.Template.Spec.Containers {
+		for _, arg := range d.Spec.Template.Spec.Containers[ci].Args {
+			name := strings.TrimLeft(arg, "-")
+			if eqIdx := strings.Index(name, "="); eqIdx != -1 {
+				name = name[:eqIdx]
+			}
+			if deprecatedMetricFlagNames[name] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // schedulerTransform applies all v0.7.0 scheduler migrations in a single pass.
 // It reads the app.kubernetes.io/version annotation from the Deployment's pod
 // template; if the version is < 0.7.0 (or absent, which defaults to 0.0.0),
 // all migrations are skipped because the v0.6 binary would reject new names.
 //
-// Migrations applied (in order):
+// Deprecated metric flag extraction (extractDeprecatedMetricFlags) and
+// core-metrics-extractor injection (withCoreMetricsExtractorPlugin) are only
+// performed when the deployment has a writable inline config-text payload.
+// If the deployment uses --config-file and still carries deprecated metric
+// flags, reconciliation is aborted with an error to prevent silent data loss.
+//
+// Migrations applied (in order, when config is writable):
 //  1. extractDeprecatedMetricFlags  – strip 5 CLI flags hard-rejected by GIE v1.4.0
 //  2. withMigrateDisaggHeadersHandler – rename prefill-header-handler → disagg-headers-handler
 //  3. withMigrateDisaggProfileHandler – rename pd-profile-handler → disagg-profile-handler,
@@ -1127,14 +1184,30 @@ func schedulerTransform(ctx context.Context, d *appsv1.Deployment) error {
 		return nil
 	}
 
-	extracted := extractDeprecatedMetricFlags(d)
+	writable := hasWritableConfigText(d)
 
-	return mutateSchedulerConfig(ctx, d,
+	if !writable && hasDeprecatedMetricFlags(d) {
+		return fmt.Errorf(
+			"scheduler deployment %s/%s uses deprecated metric flags but has no "+
+				"inline --config-text; automatic migration to core-metrics-extractor "+
+				"plugin is not possible — convert to --config-text or remove the "+
+				"deprecated flags manually",
+			d.GetNamespace(), d.GetName(),
+		)
+	}
+
+	opts := []mutateSchedulerConfigFunc{
 		withMigrateDisaggHeadersHandler,
 		withMigrateDisaggProfileHandler,
 		WithRemoveHashBlockSize,
-		withCoreMetricsExtractorPlugin(extracted),
-	)
+	}
+
+	if writable {
+		extracted := extractDeprecatedMetricFlags(d)
+		opts = append(opts, withCoreMetricsExtractorPlugin(extracted))
+	}
+
+	return mutateSchedulerConfig(ctx, d, opts...)
 }
 
 // withMigrateDisaggHeadersHandler renames the prefill-header-handler plugin to
@@ -1208,18 +1281,15 @@ func hasNonZeroThreshold(u *unstructured.Unstructured) bool {
 // extractDeprecatedMetricFlags strips the 5 metric CLI flags that GIE v1.4.0
 // hard-rejects at startup. Returns their values so they can be re-injected as
 // core-metrics-extractor plugin parameters in the EndpointPickerConfig YAML.
+//
+// Callers must verify that the deployment has a writable inline config
+// (hasWritableConfigText) before calling this function, otherwise the
+// extracted values have nowhere to be re-injected.
 func extractDeprecatedMetricFlags(d *appsv1.Deployment) map[string]string {
-	toRemove := map[string]bool{
-		"total-queued-requests-metric":     true,
-		"total-running-requests-metric":    true,
-		"kv-cache-usage-percentage-metric": true,
-		"lora-info-metric":                 true,
-		"cache-info-metric":                true,
-	}
 	var allExtracted map[string]string
 	for ci := range d.Spec.Template.Spec.Containers {
 		c := &d.Spec.Template.Spec.Containers[ci]
-		filtered, extracted := filterArgs(c.Args, toRemove)
+		filtered, extracted := filterArgs(c.Args, deprecatedMetricFlagNames)
 		c.Args = filtered
 		if len(extracted) > 0 {
 			allExtracted = extracted

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -1296,3 +1296,199 @@ func TestExtractDeprecatedMetricFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestSchedulerTransformGatesMetricFlagExtraction(t *testing.T) {
+	configYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: queue-scorer
+`
+
+	tests := []struct {
+		name           string
+		args           []string
+		expectErr      bool
+		errSubstring   string
+		validateArgs   func(g Gomega, args []string)
+		validateConfig func(g Gomega, args []string)
+	}{
+		{
+			name: "config-file with deprecated flags returns error",
+			args: []string{
+				"--config-file", "/etc/scheduler/config.yaml",
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+			},
+			expectErr:    true,
+			errSubstring: "no inline --config-text",
+		},
+		{
+			name: "no config flag with deprecated flags returns error",
+			args: []string{
+				"--grpc-port", "9002",
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+			},
+			expectErr:    true,
+			errSubstring: "no inline --config-text",
+		},
+		{
+			name: "config-file without deprecated flags succeeds",
+			args: []string{
+				"--config-file", "/etc/scheduler/config.yaml",
+				"--grpc-port", "9002",
+			},
+			expectErr: false,
+			validateArgs: func(g Gomega, args []string) {
+				g.Expect(args).To(ContainElement("--config-file"))
+				g.Expect(args).To(ContainElement("/etc/scheduler/config.yaml"))
+				g.Expect(args).To(ContainElement("--grpc-port"))
+			},
+		},
+		{
+			name: "configText camelCase with deprecated flags succeeds",
+			args: []string{
+				"--configText", configYAML,
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--grpc-port", "9002",
+			},
+			expectErr: false,
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("kv-cache-usage-percentage-metric"))
+				}
+				g.Expect(args).To(ContainElement("--grpc-port"))
+			},
+			validateConfig: func(g Gomega, args []string) {
+				for i, a := range args {
+					if a == "--configText" && i+1 < len(args) {
+						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
+						g.Expect(args[i+1]).To(ContainSubstring("vllm:kv_cache_usage_perc"))
+						return
+					}
+				}
+				g.Expect(true).To(BeFalse(), "expected --configText arg not found")
+			},
+		},
+		{
+			name: "config-text with deprecated flags succeeds (existing behavior)",
+			args: []string{
+				"--config-text", configYAML,
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--grpc-port", "9002",
+			},
+			expectErr: false,
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+				}
+				g.Expect(args).To(ContainElement("--grpc-port"))
+			},
+			validateConfig: func(g Gomega, args []string) {
+				for i, a := range args {
+					if a == "--config-text" && i+1 < len(args) {
+						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
+						return
+					}
+				}
+				g.Expect(true).To(BeFalse(), "expected --config-text arg not found")
+			},
+		},
+		{
+			name: "single-dash -config-text with deprecated flags succeeds",
+			args: []string{
+				"-config-text", configYAML,
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--grpc-port", "9002",
+			},
+			expectErr: false,
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+				}
+				g.Expect(args).To(ContainElement("--grpc-port"))
+			},
+			validateConfig: func(g Gomega, args []string) {
+				for i, a := range args {
+					if a == "-config-text" && i+1 < len(args) {
+						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
+						return
+					}
+				}
+				g.Expect(true).To(BeFalse(), "expected -config-text arg not found")
+			},
+		},
+		{
+			name: "single-dash -configText with deprecated flags succeeds",
+			args: []string{
+				"-configText", configYAML,
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--grpc-port", "9002",
+			},
+			expectErr: false,
+			validateArgs: func(g Gomega, args []string) {
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+				}
+				g.Expect(args).To(ContainElement("--grpc-port"))
+			},
+			validateConfig: func(g Gomega, args []string) {
+				for i, a := range args {
+					if a == "-configText" && i+1 < len(args) {
+						g.Expect(args[i+1]).To(ContainSubstring("core-metrics-extractor"))
+						g.Expect(args[i+1]).To(ContainSubstring("vllm:num_requests_waiting"))
+						return
+					}
+				}
+				g.Expect(true).To(BeFalse(), "expected -configText arg not found")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			d := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-scheduler",
+					Namespace: "test-ns",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"app.kubernetes.io/version": "0.7.0",
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: tt.args},
+							},
+						},
+					},
+				},
+			}
+
+			err := schedulerTransform(context.Background(), d)
+			if tt.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tt.errSubstring))
+				return
+			}
+			g.Expect(err).NotTo(HaveOccurred())
+
+			resultArgs := d.Spec.Template.Spec.Containers[0].Args
+			if tt.validateArgs != nil {
+				tt.validateArgs(g, resultArgs)
+			}
+			if tt.validateConfig != nil {
+				tt.validateConfig(g, resultArgs)
+			}
+		})
+	}
+}

--- a/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/scheduler_test.go
@@ -17,12 +17,16 @@ limitations under the License.
 package llmisvc
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 )
@@ -225,6 +229,1070 @@ func TestPreserveSchedulerConfig(t *testing.T) {
 			g := NewGomegaWithT(t)
 			result := preserveSchedulerConfig(tt.llmSvc, tt.curr)
 			g.Expect(result).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestFilterArgs(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		names             map[string]bool
+		expectedFiltered  []string
+		expectedExtracted map[string]string
+	}{
+		{
+			name:              "no matching args",
+			args:              []string{"--poolName", "test-pool", "--grpc-port", "9002"},
+			names:             map[string]bool{"kv-cache-usage-percentage-metric": true},
+			expectedFiltered:  []string{"--poolName", "test-pool", "--grpc-port", "9002"},
+			expectedExtracted: map[string]string{},
+		},
+		{
+			name:              "remove flag with separate value",
+			args:              []string{"--poolName", "test-pool", "--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc", "--grpc-port", "9002"},
+			names:             map[string]bool{"kv-cache-usage-percentage-metric": true},
+			expectedFiltered:  []string{"--poolName", "test-pool", "--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc"},
+		},
+		{
+			name:              "remove flag with equals value",
+			args:              []string{"--poolName", "test-pool", "--kv-cache-usage-percentage-metric=vllm:kv_cache_usage_perc", "--grpc-port", "9002"},
+			names:             map[string]bool{"kv-cache-usage-percentage-metric": true},
+			expectedFiltered:  []string{"--poolName", "test-pool", "--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc"},
+		},
+		{
+			name: "remove multiple flags",
+			args: []string{
+				"--poolName", "test-pool",
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--total-running-requests-metric", "vllm:num_requests_running",
+				"--grpc-port", "9002",
+			},
+			names: map[string]bool{
+				"total-queued-requests-metric":  true,
+				"total-running-requests-metric": true,
+			},
+			expectedFiltered: []string{"--poolName", "test-pool", "--grpc-port", "9002"},
+			expectedExtracted: map[string]string{
+				"total-queued-requests-metric":  "vllm:num_requests_waiting",
+				"total-running-requests-metric": "vllm:num_requests_running",
+			},
+		},
+		{
+			name:              "flag at end with no value",
+			args:              []string{"--poolName", "test-pool", "--lora-info-metric"},
+			names:             map[string]bool{"lora-info-metric": true},
+			expectedFiltered:  []string{"--poolName", "test-pool"},
+			expectedExtracted: map[string]string{"lora-info-metric": ""},
+		},
+		{
+			name:              "flag followed by another flag",
+			args:              []string{"--lora-info-metric", "--grpc-port", "9002"},
+			names:             map[string]bool{"lora-info-metric": true},
+			expectedFiltered:  []string{"--grpc-port", "9002"},
+			expectedExtracted: map[string]string{"lora-info-metric": ""},
+		},
+		{
+			name:              "empty args",
+			args:              []string{},
+			names:             map[string]bool{"kv-cache-usage-percentage-metric": true},
+			expectedFiltered:  nil,
+			expectedExtracted: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			filtered, extracted := filterArgs(tt.args, tt.names)
+			g.Expect(filtered).To(Equal(tt.expectedFiltered))
+			g.Expect(extracted).To(Equal(tt.expectedExtracted))
+		})
+	}
+}
+
+func TestWithRenamePlugin(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		oldType    string
+		newType    string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "renames matching plugin type",
+			configYAML: `
+plugins:
+- type: prefill-header-handler
+- type: queue-scorer
+`,
+			oldType: "prefill-header-handler",
+			newType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("disagg-headers-handler"))
+				g.Expect(plugins[1].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "no match - no change",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			oldType: "prefill-header-handler",
+			newType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "already renamed - idempotent",
+			configYAML: `
+plugins:
+- type: disagg-headers-handler
+`,
+			oldType: "prefill-header-handler",
+			newType: "disagg-headers-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("disagg-headers-handler"))
+			},
+		},
+		{
+			name: "renames pluginRef in schedulingProfiles",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: pd-profile-handler
+  - pluginRef: queue-scorer
+`,
+			oldType: "pd-profile-handler",
+			newType: "disagg-profile-handler",
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("disagg-profile-handler"))
+
+				profiles := obj["schedulingProfiles"].([]interface{})
+				profilePlugins := profiles[0].(map[string]interface{})["plugins"].([]interface{})
+				g.Expect(profilePlugins[0].(map[string]interface{})["pluginRef"]).To(Equal("disagg-profile-handler"))
+				g.Expect(profilePlugins[1].(map[string]interface{})["pluginRef"]).To(Equal("queue-scorer"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			fn := WithRenamePlugin(tt.oldType, tt.newType)
+			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestWithMigrateDisaggProfileParams(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "migrates deciderPluginName to deciders map",
+			configYAML: `
+plugins:
+- type: disagg-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("deciderPluginName"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+			},
+		},
+		{
+			name: "already has deciders map - idempotent",
+			configYAML: `
+plugins:
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: always-disagg-pd-decider
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+			},
+		},
+		{
+			name: "no matching plugin - no-op",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+				g.Expect(plugins[0].(map[string]interface{})["type"]).To(Equal("queue-scorer"))
+			},
+		},
+		{
+			name: "works with old pd-profile-handler type name",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("deciderPluginName"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+			},
+		},
+		{
+			name: "migrates threshold 0 to always-disagg-pd-decider",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: prefill-filter
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+				g.Expect(plugins).To(HaveLen(3))
+				g.Expect(plugins[2].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+			},
+		},
+		{
+			name: "migrates threshold 0 when decider plugin already exists",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: always-disagg-pd-decider
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+				g.Expect(plugins).To(HaveLen(2))
+			},
+		},
+		{
+			name: "strips threshold when deciderPluginName also present",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: prefix-based-pd-decider
+    threshold: 0
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("deciderPluginName"))
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "prefix-based-pd-decider"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			g.Expect(WithMigrateDisaggProfileParams(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestHasNonZeroThreshold(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		expected   bool
+	}{
+		{
+			name: "no threshold - returns false",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+`,
+			expected: false,
+		},
+		{
+			name: "threshold 0 - returns false",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+`,
+			expected: false,
+		},
+		{
+			name: "threshold 0.5 - returns true",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0.5
+`,
+			expected: true,
+		},
+		{
+			name: "threshold 1 - returns true",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 1
+`,
+			expected: true,
+		},
+		{
+			name: "deciders already present - returns false even with threshold",
+			configYAML: `
+plugins:
+- type: disagg-profile-handler
+  parameters:
+    deciders:
+      prefill: always-disagg-pd-decider
+    threshold: 0.5
+`,
+			expected: false,
+		},
+		{
+			name: "non-profile plugin with threshold - returns false",
+			configYAML: `
+plugins:
+- type: some-other-plugin
+  parameters:
+    threshold: 0.5
+`,
+			expected: false,
+		},
+		{
+			name: "no plugins - returns false",
+			configYAML: `
+schedulingProfiles:
+- name: prefill
+`,
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			g.Expect(hasNonZeroThreshold(&u)).To(Equal(tt.expected))
+		})
+	}
+}
+
+func TestWithMigrateDisaggProfileHandlerThreshold(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "skips all migration for non-zero threshold",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0.5
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal("pd-profile-handler"))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("deciders"))
+				g.Expect(params).To(HaveKey("threshold"))
+			},
+		},
+		{
+			name: "handles threshold 0 without deciderPluginName",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: prefill-filter
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+				g.Expect(plugins).To(HaveLen(3))
+				g.Expect(plugins[2].(map[string]interface{})["type"]).To(Equal("always-disagg-pd-decider"))
+			},
+		},
+		{
+			name: "handles threshold 0 when decider plugin already present",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: always-disagg-pd-decider
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal("disagg-profile-handler"))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("threshold"))
+				deciders := params["deciders"].(map[string]interface{})
+				g.Expect(deciders).To(HaveKeyWithValue("prefill", "always-disagg-pd-decider"))
+				g.Expect(plugins).To(HaveLen(2))
+			},
+		},
+		{
+			name: "handles non-zero threshold with deciderPluginName - skips all",
+			configYAML: `
+plugins:
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: prefix-based-pd-decider
+    threshold: 0.5
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				pluginMap := plugins[0].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal("pd-profile-handler"))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params).To(HaveKey("deciderPluginName"))
+				g.Expect(params).To(HaveKey("threshold"))
+				g.Expect(params).NotTo(HaveKey("deciders"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			g.Expect(withMigrateDisaggProfileHandler(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestWithRemoveHashBlockSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "removes hashBlockSize",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).NotTo(HaveKey("hashBlockSize"))
+				g.Expect(params).To(HaveKey("blockSizeTokens"))
+			},
+		},
+		{
+			name: "no hashBlockSize - no-op",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				params := plugins[0].(map[string]interface{})["parameters"].(map[string]interface{})
+				g.Expect(params).To(HaveKey("blockSizeTokens"))
+			},
+		},
+		{
+			name: "removes from multiple plugins",
+			configYAML: `
+plugins:
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+- type: precise-prefix-cache-scorer
+  parameters:
+    hashBlockSize: 32
+`,
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				for _, p := range plugins {
+					params := p.(map[string]interface{})["parameters"].(map[string]interface{})
+					g.Expect(params).NotTo(HaveKey("hashBlockSize"))
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			g.Expect(WithRemoveHashBlockSize(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestWithCoreMetricsExtractorPlugin(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		extracted  map[string]string
+		validate   func(g Gomega, obj map[string]interface{})
+	}{
+		{
+			name: "injects plugin with extracted values",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			extracted: map[string]string{
+				"total-queued-requests-metric":     "vllm:num_requests_waiting",
+				"total-running-requests-metric":    "vllm:num_requests_running",
+				"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc",
+				"lora-info-metric":                 "vllm:lora_requests_info",
+				"cache-info-metric":                "vllm:cache_config_info",
+			},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(2))
+				pluginMap := plugins[1].(map[string]interface{})
+				g.Expect(pluginMap["type"]).To(Equal(coreMetricsExtractorPlugin))
+				params := pluginMap["parameters"].(map[string]interface{})
+				g.Expect(params["defaultEngine"]).To(Equal("vllm"))
+				engineConfigs := params["engineConfigs"].([]interface{})
+				engine := engineConfigs[0].(map[string]interface{})
+				g.Expect(engine["queuedRequestsSpec"]).To(Equal("vllm:num_requests_waiting"))
+				g.Expect(engine["runningRequestsSpec"]).To(Equal("vllm:num_requests_running"))
+				g.Expect(engine["kvUsageSpec"]).To(Equal("vllm:kv_cache_usage_perc"))
+			},
+		},
+		{
+			name: "skips when plugin already exists",
+			configYAML: `
+plugins:
+- type: core-metrics-extractor
+  parameters:
+    defaultEngine: vllm
+`,
+			extracted: map[string]string{
+				"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc",
+			},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+			},
+		},
+		{
+			name: "skips when no values extracted",
+			configYAML: `
+plugins:
+- type: queue-scorer
+`,
+			extracted: map[string]string{},
+			validate: func(g Gomega, obj map[string]interface{}) {
+				plugins := obj["plugins"].([]interface{})
+				g.Expect(plugins).To(HaveLen(1))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			var obj map[string]interface{}
+			g.Expect(yaml.Unmarshal([]byte(tt.configYAML), &obj)).To(Succeed())
+			u := unstructured.Unstructured{Object: obj}
+			fn := withCoreMetricsExtractorPlugin(tt.extracted)
+			g.Expect(fn(context.Background(), &u)).To(Succeed())
+			tt.validate(g, u.Object)
+		})
+	}
+}
+
+func TestSchedulerTransform(t *testing.T) {
+	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+`
+
+	tests := []struct {
+		name           string
+		version        string
+		validateConfig func(g Gomega, configText string)
+	}{
+		{
+			name:    "applies all migrations for v0.7.0",
+			version: "0.7.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("prefill: always-disagg-pd-decider"))
+				g.Expect(configText).NotTo(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
+			},
+		},
+		{
+			name:    "skips all migrations for v0.6.0",
+			version: "0.6.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).To(ContainSubstring("hashBlockSize"))
+			},
+		},
+		{
+			name:    "skips all migrations when no version annotation",
+			version: "",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).To(ContainSubstring("hashBlockSize"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"app.kubernetes.io/version": tt.version,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: []string{"--config-text", oldConfigYAML}},
+							},
+						},
+					},
+				},
+			}
+
+			g.Expect(schedulerTransform(context.Background(), d)).To(Succeed())
+
+			configText := d.Spec.Template.Spec.Containers[0].Args[1]
+			tt.validateConfig(g, configText)
+		})
+	}
+}
+
+func TestSchedulerTransformThreshold(t *testing.T) {
+	tests := []struct {
+		name           string
+		configYAML     string
+		version        string
+		validateConfig func(g Gomega, configText string)
+	}{
+		{
+			name: "skips profile handler rename for non-zero threshold",
+			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: pd-profile-handler
+  parameters:
+    threshold: 0.5
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+`,
+			version: "0.7.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("threshold"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+			},
+		},
+		{
+			name: "skips profile handler for non-zero threshold with deciderPluginName",
+			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: prefix-based-pd-decider
+    threshold: 0.5
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+`,
+			version: "0.7.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).To(ContainSubstring("threshold"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+			},
+		},
+		{
+			name: "migrates threshold 0 in full transform",
+			configYAML: `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: pd-profile-handler
+  parameters:
+    threshold: 0
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+`,
+			version: "0.7.0",
+			validateConfig: func(g Gomega, configText string) {
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("prefill: always-disagg-pd-decider"))
+				g.Expect(configText).NotTo(ContainSubstring("threshold"))
+				g.Expect(configText).To(ContainSubstring("always-disagg-pd-decider"))
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"app.kubernetes.io/version": tt.version,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: []string{"--config-text", tt.configYAML}},
+							},
+						},
+					},
+				},
+			}
+
+			g.Expect(schedulerTransform(context.Background(), d)).To(Succeed())
+
+			configText := d.Spec.Template.Spec.Containers[0].Args[1]
+			tt.validateConfig(g, configText)
+		})
+	}
+}
+
+func TestFullMigrationPipeline(t *testing.T) {
+	// Realistic old v0.6 config with all deprecated features.
+	oldConfigYAML := `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: prefill-header-handler
+- type: prefill-filter
+- type: decode-filter
+- type: queue-scorer
+- type: prefix-cache-scorer
+  parameters:
+    hashBlockSize: 64
+    blockSizeTokens: 16
+    indexerConfig:
+      tokenProcessorConfig:
+        batchSize: 1024
+- type: max-score-picker
+- type: always-disagg-pd-decider
+- type: pd-profile-handler
+  parameters:
+    deciderPluginName: always-disagg-pd-decider
+schedulingProfiles:
+- name: prefill
+  plugins:
+  - pluginRef: prefill-filter
+  - pluginRef: queue-scorer
+  - pluginRef: max-score-picker
+- name: decode
+  plugins:
+  - pluginRef: decode-filter
+  - pluginRef: prefix-cache-scorer
+  - pluginRef: queue-scorer
+  - pluginRef: max-score-picker
+`
+
+	tests := []struct {
+		name           string
+		version        string
+		extraArgs      []string
+		validateConfig func(g Gomega, configText string)
+		validateArgs   func(g Gomega, args []string)
+	}{
+		{
+			name:    "full migration of old v0.6 config to v0.7",
+			version: "0.7.0",
+			extraArgs: []string{
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--total-running-requests-metric", "vllm:num_requests_running",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--grpc-port", "9002",
+			},
+			validateConfig: func(g Gomega, configText string) {
+				// Plugin renames applied
+				g.Expect(configText).To(ContainSubstring("disagg-headers-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("disagg-profile-handler"))
+				g.Expect(configText).NotTo(ContainSubstring("pd-profile-handler"))
+
+				// Parameter restructuring applied
+				g.Expect(configText).To(ContainSubstring("prefill: always-disagg-pd-decider"))
+				g.Expect(configText).NotTo(ContainSubstring("deciderPluginName"))
+
+				// Deprecated field removed
+				g.Expect(configText).NotTo(ContainSubstring("hashBlockSize"))
+
+				// Pre-existing migrations applied
+				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
+
+				// CLI flag values moved to core-metrics-extractor plugin
+				g.Expect(configText).To(ContainSubstring("core-metrics-extractor"))
+				g.Expect(configText).To(ContainSubstring("vllm:num_requests_waiting"))
+				g.Expect(configText).To(ContainSubstring("vllm:num_requests_running"))
+				g.Expect(configText).To(ContainSubstring("vllm:kv_cache_usage_perc"))
+
+				// Unchanged plugins preserved
+				g.Expect(configText).To(ContainSubstring("prefill-filter"))
+				g.Expect(configText).To(ContainSubstring("decode-filter"))
+				g.Expect(configText).To(ContainSubstring("queue-scorer"))
+				g.Expect(configText).To(ContainSubstring("max-score-picker"))
+			},
+			validateArgs: func(g Gomega, args []string) {
+				// Metric flags removed
+				for _, a := range args {
+					g.Expect(a).NotTo(ContainSubstring("total-queued-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("total-running-requests-metric"))
+					g.Expect(a).NotTo(ContainSubstring("kv-cache-usage-percentage-metric"))
+				}
+				// Non-metric flags preserved
+				g.Expect(args).To(ContainElement("--grpc-port"))
+				g.Expect(args).To(ContainElement("9002"))
+			},
+		},
+		{
+			name:    "old config left untouched for v0.6.0",
+			version: "0.6.0",
+			extraArgs: []string{
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+			},
+			validateConfig: func(g Gomega, configText string) {
+				// v0.7 renames NOT applied
+				g.Expect(configText).To(ContainSubstring("prefill-header-handler"))
+				g.Expect(configText).To(ContainSubstring("pd-profile-handler"))
+				g.Expect(configText).To(ContainSubstring("deciderPluginName"))
+				g.Expect(configText).To(ContainSubstring("hashBlockSize"))
+
+				// No core-metrics-extractor injected
+				g.Expect(configText).NotTo(ContainSubstring("core-metrics-extractor"))
+
+				// Pre-existing migrations still applied (unconditional)
+				g.Expect(configText).To(ContainSubstring("blockSizeTokens"))
+			},
+			validateArgs: func(g Gomega, args []string) {
+				// CLI flags preserved for v0.6 binary
+				g.Expect(args).To(ContainElement("--total-queued-requests-metric"))
+				g.Expect(args).To(ContainElement("vllm:num_requests_waiting"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+
+			args := append([]string{"--config-text", oldConfigYAML}, tt.extraArgs...)
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{
+								"app.kubernetes.io/version": tt.version,
+							},
+						},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: args},
+							},
+						},
+					},
+				},
+			}
+
+			ctx := context.Background()
+
+			// Stage 1: unconditional pre-v0.7 migrations
+			g.Expect(mutateSchedulerConfig(ctx, d,
+				WithMigrateTokenProcessorConfig,
+				WithMigrateBlockSizeToBlockSizeTokens,
+			)).To(Succeed())
+
+			// Stage 2: version-gated v0.7 migrations (single pass)
+			g.Expect(schedulerTransform(ctx, d)).To(Succeed())
+
+			resultArgs := d.Spec.Template.Spec.Containers[0].Args
+			for i, a := range resultArgs {
+				if a == "--config-text" && i+1 < len(resultArgs) {
+					tt.validateConfig(g, resultArgs[i+1])
+				}
+			}
+			tt.validateArgs(g, resultArgs)
+		})
+	}
+}
+
+func TestExtractDeprecatedMetricFlags(t *testing.T) {
+	tests := []struct {
+		name              string
+		args              []string
+		expectedFiltered  []string
+		expectedExtracted map[string]string
+	}{
+		{
+			name: "extracts all metric flags",
+			args: []string{
+				"--config-text", "someyaml",
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--grpc-port", "9002",
+			},
+			expectedFiltered: []string{"--config-text", "someyaml", "--grpc-port", "9002"},
+			expectedExtracted: map[string]string{
+				"total-queued-requests-metric":     "vllm:num_requests_waiting",
+				"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc",
+			},
+		},
+		{
+			name:              "no metric flags - returns nil",
+			args:              []string{"--config-text", "someyaml", "--grpc-port", "9002"},
+			expectedFiltered:  []string{"--config-text", "someyaml", "--grpc-port", "9002"},
+			expectedExtracted: nil,
+		},
+		{
+			name: "extracts all five deprecated flags",
+			args: []string{
+				"--total-queued-requests-metric", "vllm:num_requests_waiting",
+				"--total-running-requests-metric", "vllm:num_requests_running",
+				"--kv-cache-usage-percentage-metric", "vllm:kv_cache_usage_perc",
+				"--lora-info-metric", "vllm:lora_requests_info",
+				"--cache-info-metric", "vllm:cache_config_info",
+			},
+			expectedFiltered: nil,
+			expectedExtracted: map[string]string{
+				"total-queued-requests-metric":     "vllm:num_requests_waiting",
+				"total-running-requests-metric":    "vllm:num_requests_running",
+				"kv-cache-usage-percentage-metric": "vllm:kv_cache_usage_perc",
+				"lora-info-metric":                 "vllm:lora_requests_info",
+				"cache-info-metric":                "vllm:cache_config_info",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			d := &appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{Name: "main", Args: tt.args},
+							},
+						},
+					},
+				},
+			}
+			extracted := extractDeprecatedMetricFlags(d)
+			g.Expect(d.Spec.Template.Spec.Containers[0].Args).To(Equal(tt.expectedFiltered))
+			g.Expect(extracted).To(Equal(tt.expectedExtracted))
 		})
 	}
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/kserve/kserve/pull/5433 to rhoai-3.4.

Adds migration logic for llm-d v0.6 components upgrade, including go.sum conflict resolution after cherry-pick.