### PR TITLE
Fix kv-cache routing sample to use sha256_cbor for hashing

### DIFF
--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/README.md
@@ -23,7 +23,7 @@ This example demonstrates precise prefix cache routing with cache block tracking
 - Model: Qwen2.5-7B-Instruct
 - Replicas: 2
 - GPU per replica: 1
-- Prefix caching algorithm: SHA256 CBOR 64-bit
+- Prefix caching algorithm: SHA256 CBOR
 - Block size: 64 tokens
 - KV cache tracking: Enabled via ZMQ
 
@@ -65,7 +65,7 @@ Key vLLM settings for cache routing:
 
 ```yaml
 VLLM_ADDITIONAL_ARGS:
-  - --prefix-caching-hash-algo sha256_cbor_64bit
+  - --prefix-caching-hash-algo sha256_cbor
   - --block-size 64
   - --kv_transfer_config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'
   - --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","endpoint":"tcp://...:5557","topic":"kv@${POD_IP}@..."}'

--- a/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
+++ b/docs/samples/llmisvc/precise-prefix-kv-cache-routing/llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml
@@ -49,7 +49,7 @@ spec:
         env:
           # Configure vLLM for prefix caching with KV cache event publishing
           - name: VLLM_ADDITIONAL_ARGS
-            value: "--prefix-caching-hash-algo sha256 --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
+            value: "--prefix-caching-hash-algo sha256_cbor --block-size 64 --kv_transfer_config '{\"kv_connector\":\"NixlConnector\",\"kv_role\":\"kv_both\"}' --kv-events-config '{\"enable_kv_cache_events\":true,\"publisher\":\"zmq\",\"endpoint\":\"tcp://{{ ChildName .ObjectMeta.Name `-epp-service` }}:5557\",\"topic\":\"kv@${POD_IP}@Qwen/Qwen2.5-7B-Instruct\"}'"
           # Pod IP used in KV cache event topic
           - name: POD_IP
             valueFrom:


### PR DESCRIPTION

**What this PR does / why we need it**:

Backport of upstream kserve PR [#5484](https://github.com/kserve/kserve/pull/5484) to `rhoai-3.5-ea.1`.

The `precise-prefix-kv-cache-routing` sample passed `--prefix-caching-hash-algo sha256` to vLLM, but the EPP's prefix-cache scorer requires the cbor variant so that its hash predictions align with vLLM's prefix-cache block hashes. With mismatched algorithms the scheduler can't predict which decode pod holds a cached prefix, falls back to non-prefix-aware scoring, and the sample's prefix-cache routing demonstration produces no cache hits.

Updated three locations in this branch's copy of the sample directory to use `sha256_cbor`:
- `llm-inference-service-qwen2-7b-gpu-kv-cache-routing.yaml` — vLLM env-var value
- `README.md` — "Configuration" bullet ("Prefix caching algorithm")
- `README.md` — vLLM settings code block

Covers Jira fix version `rhoai-3.5.EA1`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

Jira: [RHOAIENG-60148](https://issues.redhat.com/browse/RHOAIENG-60148)

**Feature/Issue validation/testing**:

- [x] YAML well-formedness verified locally.
- [x] Diff limited to the three intended changes (one in YAML env-var, two in README — descriptive bullet and vLLM settings snippet).

Algorithm correctness for `sha256_cbor` is already covered by existing tests on NVIDIA and AMD hardware (per scrum confirmation), so no new test is added for this sample-only update.

**Special notes for your reviewer**:

Sample-only change. No controller, CRD, or image versions are modified. Backport of upstream PR [#5484](https://github.com/kserve/kserve/pull/5484); the `rhoai-3.5-ea.1` README contains some descriptive content not present upstream (the "Prefix caching algorithm: SHA256 CBOR 64-bit" bullet), which is updated here as well so the documentation no longer names the wrong algorithm. Companion downstream PR for `rhoai-3.4`: red-hat-data-services/kserve#4346.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works? — N/A, sample doc fix; existing tests cover the algorithm.
- [ ] Has code been commented, particularly in hard-to-understand areas? — N/A.
- [x] Have you made corresponding changes to the documentation? — README in the same sample directory is updated in this PR.
- [x] Have you linked the JIRA issue(s) to this PR? — [RHOAIENG-60148](https://redhat.atlassian.net/browse/RHOAIENG-60148).

**Release note**:
```release-note
NONE