### PR TITLE
[RHOAIENG-59246] pin python-dotenv>=1.2.2 for CVE-2026-28684

### DIFF
--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4770,13 +4770,13 @@ six = ">=1.5"
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.0"
+version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "python_dotenv-1.1.0-py3-none-any.whl", hash = "sha256:d7c01d9e2293916c18baf562d95698754b0dbbb5e74d457c45d4f6561fb9d55d"},
-    {file = "python_dotenv-1.1.0.tar.gz", hash = "sha256:41f90bc6f5f177fb41f53e87666db362025010eb28f60a01c9143bfa33a2b2d5"},
+    {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
+    {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
 ]
 
 [package.extras]
@@ -7032,4 +7032,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "f098fac6810e44cb09206fecf92fcfb669a80a7c6788db94036fb1ae067d194d"
+content-hash = "fae4f905b7d271824163c266b4b552825040e657a29921ca89860cf2a395c597"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -67,6 +67,9 @@ PyJWT = ">=2.12.0"
 # CVE-2026-30922 / CVE-2026-23490 pyasn1 Vulnerable to Denial of Service
 # Pinning because it is a transitive dependency.
 pyasn1 = ">=0.6.3"
+# CVE-2026-28684 python-dotenv: Arbitrary file overwrite via symbolic link following
+# Pinning because it is a transitive dependency.
+python-dotenv = ">=1.2.2"
 
 # Storage dependencies. They can be opted into by apps.
 requests = { version = "^2.32.2", optional = true }


### PR DESCRIPTION
**What this PR does / why we need it**:
Pins `python-dotenv>=1.2.2` to fix CVE-2026-28684. python-dotenv's `set_key()` and `unset_key()` follow symbolic links when rewriting `.env` files, allowing a local attacker to overwrite arbitrary files. This is a transitive dependency pulled in via `pydantic-settings`.

**Which issue(s) this PR fixes**:
Fixes https://issues.redhat.com/browse/RHOAIENG-59246

**Type of changes**

- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:

- [x] `poetry lock --no-update` passes
- [x] Lock file updated with python-dotenv 1.2.2

**Special notes for your reviewer**:
Minimal diff — only pyproject.toml pin addition and poetry.lock version bump.

**Release note**:
```release-note
NONE
```