### PR TITLE
FIPS compliance for modelcache images

### DIFF
--- a/Dockerfiles/localmodel-agent.Dockerfile.konflux
+++ b/Dockerfiles/localmodel-agent.Dockerfile.konflux
@@ -21,7 +21,7 @@ COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -tags "${GOTAGS}" -a -o localmodelnode-agent ./cmd/${CMD}
+    CGO_ENABLED=1 GOOS=linux GOFLAGS=-mod=readonly GOEXPERIMENT=strictfipsruntime go build -tags "${GOTAGS},strictfipsruntime" -a -o localmodelnode-agent ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM registry.redhat.io/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea

--- a/Dockerfiles/localmodel.Dockerfile.konflux
+++ b/Dockerfiles/localmodel.Dockerfile.konflux
@@ -20,7 +20,7 @@ COPY cmd/${CMD}/ cmd/${CMD}/
 COPY pkg/    pkg/
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    CGO_ENABLED=0 GOOS=linux GOFLAGS=-mod=readonly go build -a -o localmodel-manager ./cmd/${CMD}
+    CGO_ENABLED=1 GOOS=linux GOFLAGS=-mod=readonly GOEXPERIMENT=strictfipsruntime go build -tags "strictfipsruntime" -a -o localmodel-manager ./cmd/${CMD}
 
 # Copy the controller-manager into a thin image
 FROM registry.redhat.io/ubi9/ubi-minimal@sha256:175bafd5bc7893540ed6234bb979acfe3574fd6570e6762bbc527c757f854cea


### PR DESCRIPTION
## Summary
Cherry-pick of #4356 to `rhoai-3.5-ea.1`.

- Sets `CGO_ENABLED=1` and add `GOEXPERIMENT=strictfipsruntime` and `-tags strictfipsruntime` for `localmodel controller` and `localmodelnode agent` Konflux Dockerfiles. 
This is needed to pass the FIPS compliance check.

Fixes:
- https://redhat.atlassian.net/browse/RHOAIENG-62656
- https://redhat.atlassian.net/browse/RHOAIENG-62657
