### PR TITLE
chore: use digest instead of floating tags (konflux requirement)

### DIFF
--- a/Dockerfiles/Dockerfile.konflux.kserve-module-controller
+++ b/Dockerfiles/Dockerfile.konflux.kserve-module-controller
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset@sha256:90a36bc2013b3fcb28e2a4b082c9b895d7c2c679e58b95aed9721970f3339d0e AS builder
 ENV PATH="$PATH:/opt/app-root/src/go/bin"
 
 USER root
@@ -21,7 +21,7 @@ COPY config/               ../config/
 RUN bash hack/get_kserve_manifests.sh
 
 # Runtime
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:1bc3c5c15720506a0cf48adfdf8b623dfe704377e007d7bbae8d14876392ca6a
 RUN microdnf install -y --disablerepo=* --enablerepo=ubi-9-baseos-rpms shadow-utils && \
     microdnf clean all && \
     useradd kserve -m -u 1000 && \


### PR DESCRIPTION
Per the title

Tested with:

```sh
podman build -f Dockerfiles/Dockerfile.konflux.kserve-module-controller .
```
