### PR TITLE
[rhoai-3.5ea2] fix(llmisvc): default EPP port to 9002 when endpointPickerRef omits port (#5698)

### DIFF
--- a/pkg/apis/gie/v1alpha2pool/inferencepool_conversion.go
+++ b/pkg/apis/gie/v1alpha2pool/inferencepool_conversion.go
@@ -257,6 +257,13 @@ func convertExtensionRefToV1(src *Extension) (v1.EndpointPickerRef, error) {
 	}
 	endpointPickerRef.FailureMode = failureMode
 
+	// The v1 InferencePool CRD requires port when kind is "Service" or unspecified. Old
+	// v1alpha2 pools may omit PortNumber, which would make the converted v1 object fail
+	// the CEL rule. Default to the standard EPP gRPC port (9002).
+	if (endpointPickerRef.Port == nil || endpointPickerRef.Port.Number == 0) && (endpointPickerRef.Kind == "Service" || endpointPickerRef.Kind == "") {
+		endpointPickerRef.Port = ptr.To(v1.Port{Number: 9002})
+	}
+
 	return endpointPickerRef, nil
 }
 

--- a/pkg/apis/gie/v1alpha2pool/inferencepool_test.go
+++ b/pkg/apis/gie/v1alpha2pool/inferencepool_test.go
@@ -273,6 +273,95 @@ func TestConvertTo_ObjectMetaDeepCopy(t *testing.T) {
 	assert.Equal(t, "value", v1Pool.Labels["key"])
 }
 
+func TestConvertTo_NilPortDefaultsTo9002WhenKindIsService(t *testing.T) {
+	original := &InferencePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InferencePool",
+			APIVersion: "inference.networking.x-k8s.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+			Namespace: "default",
+		},
+		Spec: InferencePoolSpec{
+			Selector:         map[LabelKey]LabelValue{"app": "vllm"},
+			TargetPortNumber: 8000,
+			ExtensionRef: Extension{
+				Kind:        ptr.To(Kind("Service")),
+				Name:        "my-epp",
+				FailureMode: ptr.To(FailOpen),
+			},
+		},
+	}
+
+	v1Pool := &v1.InferencePool{}
+	err := original.ConvertTo(v1Pool)
+	require.NoError(t, err)
+
+	require.NotNil(t, v1Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, v1.PortNumber(9002), v1Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
+func TestConvertTo_NilPortDefaultsTo9002WhenKindIsNil(t *testing.T) {
+	original := &InferencePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InferencePool",
+			APIVersion: "inference.networking.x-k8s.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+			Namespace: "default",
+		},
+		Spec: InferencePoolSpec{
+			Selector:         map[LabelKey]LabelValue{"app": "vllm"},
+			TargetPortNumber: 8000,
+			ExtensionRef: Extension{
+				Kind:        nil,
+				Name:        "my-epp",
+				FailureMode: ptr.To(FailClose),
+			},
+		},
+	}
+
+	v1Pool := &v1.InferencePool{}
+	err := original.ConvertTo(v1Pool)
+	require.NoError(t, err)
+
+	assert.Equal(t, v1.Kind("Service"), v1Pool.Spec.EndpointPickerRef.Kind)
+	require.NotNil(t, v1Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, v1.PortNumber(9002), v1Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
+func TestConvertTo_ExplicitPortIsPreserved(t *testing.T) {
+	original := &InferencePool{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "InferencePool",
+			APIVersion: "inference.networking.x-k8s.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pool",
+			Namespace: "default",
+		},
+		Spec: InferencePoolSpec{
+			Selector:         map[LabelKey]LabelValue{"app": "vllm"},
+			TargetPortNumber: 8000,
+			ExtensionRef: Extension{
+				Kind:        ptr.To(Kind("Service")),
+				Name:        "my-epp",
+				PortNumber:  ptr.To(PortNumber(8080)),
+				FailureMode: ptr.To(FailClose),
+			},
+		},
+	}
+
+	v1Pool := &v1.InferencePool{}
+	err := original.ConvertTo(v1Pool)
+	require.NoError(t, err)
+
+	require.NotNil(t, v1Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, v1.PortNumber(8080), v1Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
 func TestDeepCopy(t *testing.T) {
 	pool := &InferencePool{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -398,6 +398,22 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		}
 	}
 
+	// The v1 InferencePool CRD requires port when endpointPickerRef.kind is "Service" (or
+	// unspecified, which defaults to "Service"). Configs created before GIE v1.2.0
+	// omit the port field entirely. Without this default the controller's
+	// dry-run update fails the CEL rule: "port is required when kind is 'Service' or
+	// unspecified (defaults to 'Service')". We check both Kind=="Service" and Kind==""
+	// because the kubebuilder default is only applied server-side during admission, not
+	// during in-process deserialization.
+	if llmSvcCfg.Spec.Router != nil &&
+		llmSvcCfg.Spec.Router.Scheduler != nil &&
+		llmSvcCfg.Spec.Router.Scheduler.Pool != nil &&
+		llmSvcCfg.Spec.Router.Scheduler.Pool.Spec != nil &&
+		(llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port == nil || llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port.Number == 0) &&
+		(llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Kind == "Service" || llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Kind == "") {
+		llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port = ptr.To(igwapi.Port{Number: 9002})
+	}
+
 	// Skip validation when we're only using the result for matching (not for reconciliation).
 	// When skipClearSchedulerConfigRef is true, both Inline and Ref may be set, which would fail validation.
 	if !options.skipClearSchedulerConfigRef {

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1784,6 +1784,78 @@ schedulingProfiles:
 				"AMD instance should not create a scheduler deployment")
 		})
 	})
+
+	Context("EPP port defaulting for upgrade compatibility", func() {
+		// The port defaulting for configs that omit port (pre-GIE-v1.2.0 upgrade
+		// scenario) is covered by the v1alpha2pool conversion (convertExtensionRefToV1)
+		// and combineBaseRefsConfig. Integration tests for the nil-port case are not
+		// feasible here because the v1alpha2 CEL rule rejects creating configs without
+		// port, and the v1alpha1 conversion defaults port to 9002 during ConvertTo.
+
+		It("should not override explicitly set EPP port", func(ctx SpecContext) {
+			svcName := "test-llm-port-explicit"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			schedulerCfg := LLMInferenceServiceConfig("kserve-config-llm-scheduler",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
+			)
+			schedulerCfg.Spec.Router = &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Pool: &v1alpha2.InferencePoolSpec{
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Kind:        "Service",
+								Name:        igwapi.ObjectName(kmeta.ChildName(svcName, "-epp-service")),
+								Port:        ptr.To(igwapi.Port{Number: 8080}),
+								FailureMode: igwapi.EndpointPickerFailOpen,
+							},
+							Selector: igwapi.LabelSelector{
+								MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+									"app": "placeholder",
+								},
+							},
+							TargetPorts: []igwapi.Port{{Number: 8000}},
+						},
+					},
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "main",
+							Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1",
+							Ports: []corev1.ContainerPort{
+								{Name: "grpc", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "grpc-health", ContainerPort: 9003, Protocol: corev1.ProtocolTCP},
+								{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+							},
+						}},
+					},
+				},
+			}
+			Expect(envTest.Client.Create(ctx, schedulerCfg)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			ip := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, client.ObjectKey{
+					Name:      svcName + "-inference-pool",
+					Namespace: testNs.Name,
+				}, ip)).To(Succeed())
+				g.Expect(ip.Spec.EndpointPickerRef.Port).NotTo(BeNil())
+				g.Expect(ip.Spec.EndpointPickerRef.Port.Number).To(Equal(igwapi.PortNumber(8080)))
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
 })
 
 // schedulerContainerName is the expected name of the main container in the scheduler deployment


### PR DESCRIPTION
cherry-pick of https://github.com/kserve/kserve/pull/5698/changes

https://redhat.atlassian.net/browse/RHOAIENG-70227

The v1 InferencePool CRD (GIE v1.5.0) has a CEL validation rule requiring port when kind is "Service" or unspecified. Configs created before GIE v1.2.0 omit the port field entirely, causing SchedulerReconcileError on upgrade.

Default port to 9002 (standard EPP gRPC port) in two places:

v1alpha2-to-v1 InferencePool conversion
combineBaseRefsConfig after merging all config layers
Both sites check Kind=="Service" and Kind=="" because the kubebuilder default is only applied server-side during admission, not during in-process deserialization.