### PR TITLE
[rhoai-3.4] fix(llmisvc): default EPP port to 9002 when endpointPickerRef omits port (#5698)

### DIFF
--- a/pkg/apis/serving/v1alpha1/llm_inference_service_conversion.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_conversion.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 	igwapiv1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	igwapiv1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
@@ -430,6 +431,14 @@ func convertInferencePoolSpecToV1(src *igwapiv1alpha2.InferencePoolSpec) *igwapi
 		// Return nil rather than an empty spec — callers nil-check Pool.Spec, and an
 		// empty spec would bypass those guards with invalid zero-value fields.
 		return nil
+	}
+
+	// The v1 InferencePool CRD requires port when kind is "Service" or unspecified. Old
+	// v1alpha2 pools may omit PortNumber, which would make the converted v1 object fail
+	// the CEL rule. Default to the standard EPP gRPC port (9002).
+	endpointPickerRef := &dstPool.Spec.EndpointPickerRef
+	if (endpointPickerRef.Port == nil || endpointPickerRef.Port.Number == 0) && (endpointPickerRef.Kind == "Service" || endpointPickerRef.Kind == "") {
+		endpointPickerRef.Port = ptr.To(igwapiv1.Port{Number: 9002})
 	}
 
 	return &dstPool.Spec

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_conversion_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_conversion_test.go
@@ -341,6 +341,139 @@ func TestLLMInferenceServiceConversion_PreservesInferencePoolSpec(t *testing.T) 
 	assert.Equal(t, igwapiv1alpha2.ObjectName("my-epp"), v1a2Spec.ExtensionRef.Name)
 }
 
+func TestLLMInferenceServiceConversion_NilPortDefaultsTo9002WhenKindIsService(t *testing.T) {
+	modelName := "test-model"
+	eppKind := igwapiv1alpha2.Kind("Service")
+	eppFailureMode := igwapiv1alpha2.ExtensionFailureMode("FailOpen")
+
+	src := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-isvc-nil-port-service",
+			Namespace: "default",
+		},
+		Spec: LLMInferenceServiceSpec{
+			Model: LLMModelSpec{
+				URI:  apis.URL{Scheme: "hf", Host: "meta-llama/Llama-2-7b"},
+				Name: &modelName,
+			},
+			Router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapiv1alpha2.InferencePoolSpec{
+							Selector: map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{
+								"app": "vllm",
+							},
+							TargetPortNumber: 8000,
+							ExtensionRef: igwapiv1alpha2.Extension{
+								Kind:        &eppKind,
+								Name:        "my-epp",
+								FailureMode: &eppFailureMode,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &v1alpha2.LLMInferenceService{}
+	err := src.ConvertTo(dst)
+	require.NoError(t, err)
+
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec)
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, igwapiv1.PortNumber(9002), dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
+func TestLLMInferenceServiceConversion_NilPortDefaultsTo9002WhenKindIsNil(t *testing.T) {
+	modelName := "test-model"
+	eppFailureMode := igwapiv1alpha2.ExtensionFailureMode("FailClose")
+
+	src := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-isvc-nil-port-nil-kind",
+			Namespace: "default",
+		},
+		Spec: LLMInferenceServiceSpec{
+			Model: LLMModelSpec{
+				URI:  apis.URL{Scheme: "hf", Host: "meta-llama/Llama-2-7b"},
+				Name: &modelName,
+			},
+			Router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapiv1alpha2.InferencePoolSpec{
+							Selector: map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{
+								"app": "vllm",
+							},
+							TargetPortNumber: 8000,
+							ExtensionRef: igwapiv1alpha2.Extension{
+								Kind:        nil,
+								Name:        "my-epp",
+								FailureMode: &eppFailureMode,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &v1alpha2.LLMInferenceService{}
+	err := src.ConvertTo(dst)
+	require.NoError(t, err)
+
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec)
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, igwapiv1.PortNumber(9002), dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
+func TestLLMInferenceServiceConversion_ExplicitPortIsPreserved(t *testing.T) {
+	modelName := "test-model"
+	eppKind := igwapiv1alpha2.Kind("Service")
+	eppPort := igwapiv1alpha2.PortNumber(8080)
+	eppFailureMode := igwapiv1alpha2.ExtensionFailureMode("FailClose")
+
+	src := &LLMInferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-llm-isvc-explicit-port",
+			Namespace: "default",
+		},
+		Spec: LLMInferenceServiceSpec{
+			Model: LLMModelSpec{
+				URI:  apis.URL{Scheme: "hf", Host: "meta-llama/Llama-2-7b"},
+				Name: &modelName,
+			},
+			Router: &RouterSpec{
+				Scheduler: &SchedulerSpec{
+					Pool: &InferencePoolSpec{
+						Spec: &igwapiv1alpha2.InferencePoolSpec{
+							Selector: map[igwapiv1alpha2.LabelKey]igwapiv1alpha2.LabelValue{
+								"app": "vllm",
+							},
+							TargetPortNumber: 8000,
+							ExtensionRef: igwapiv1alpha2.Extension{
+								Kind:        &eppKind,
+								Name:        "my-epp",
+								PortNumber:  &eppPort,
+								FailureMode: &eppFailureMode,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dst := &v1alpha2.LLMInferenceService{}
+	err := src.ConvertTo(dst)
+	require.NoError(t, err)
+
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec)
+	require.NotNil(t, dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port)
+	assert.Equal(t, igwapiv1.PortNumber(8080), dst.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port.Number)
+}
+
 func TestLLMInferenceServiceConversion_PreservesPoolRef(t *testing.T) {
 	modelName := "test-model"
 

--- a/pkg/controller/v1alpha2/llmisvc/config_merge.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge.go
@@ -334,6 +334,22 @@ func (r *LLMISVCReconciler) combineBaseRefsConfig(ctx context.Context, llmSvc *v
 		}
 	}
 
+	// The v1 InferencePool CRD requires port when endpointPickerRef.kind is "Service" (or
+	// unspecified, which defaults to "Service"). Configs created before GIE v1.2.0
+	// omit the port field entirely. Without this default the controller's
+	// dry-run update fails the CEL rule: "port is required when kind is 'Service' or
+	// unspecified (defaults to 'Service')". We check both Kind=="Service" and Kind==""
+	// because the kubebuilder default is only applied server-side during admission, not
+	// during in-process deserialization.
+	if llmSvcCfg.Spec.Router != nil &&
+		llmSvcCfg.Spec.Router.Scheduler != nil &&
+		llmSvcCfg.Spec.Router.Scheduler.Pool != nil &&
+		llmSvcCfg.Spec.Router.Scheduler.Pool.Spec != nil &&
+		(llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port == nil || llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port.Number == 0) &&
+		(llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Kind == "Service" || llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Kind == "") {
+		llmSvcCfg.Spec.Router.Scheduler.Pool.Spec.EndpointPickerRef.Port = ptr.To(igwapi.Port{Number: 9002})
+	}
+
 	// Skip validation when we're only using the result for matching (not for reconciliation).
 	// When skipClearSchedulerConfigRef is true, both Inline and Ref may be set, which would fail validation.
 	if !options.skipClearSchedulerConfigRef {

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -26,12 +26,14 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
@@ -1484,6 +1486,335 @@ schedulingProfiles:
 				g.Expect(updatedSchedulerSA.ImagePullSecrets).To(ContainElement(
 					corev1.LocalObjectReference{Name: "new-secret"}))
 				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("v0.9.0 prefix-cache-scorer parameter removal", func() {
+		It("should remove all parameters except prefixMatchInfoProducerName from prefix-cache-scorer", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-param-removal"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithPrefixCacheParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+    prefixMatchInfoProducerName: my-producer
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithPrefixCacheParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).To(ContainSubstring("prefixMatchInfoProducerName: my-producer"))
+				g.Expect(configText).NotTo(ContainSubstring("blockSizeTokens"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should remove parameters entirely when no prefixMatchInfoProducerName is present", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-param-all-removed"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithOnlyDeprecatedParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+  parameters:
+    blockSizeTokens: 16
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithOnlyDeprecatedParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).NotTo(ContainSubstring("blockSizeTokens"))
+				g.Expect(configText).NotTo(ContainSubstring("parameters"))
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+
+		It("should not touch prefix-cache-scorer without parameters", func(ctx SpecContext) {
+			svcName := "test-llm-pcs-no-params"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			configWithNoParams := `
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: single-profile-handler
+- type: prefix-cache-scorer
+- type: queue-scorer
+- type: max-score-picker
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+  - pluginRef: max-score-picker
+`
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithSchedulerConfigInline(configWithNoParams),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			expectedDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				if err := envTest.Get(ctx, types.NamespacedName{
+					Name:      kmeta.ChildName(svcName, "-kserve-router-scheduler"),
+					Namespace: testNs.Name,
+				}, expectedDeployment); err != nil {
+					return err
+				}
+
+				configText, found := getSchedulerConfigText(expectedDeployment)
+				g.Expect(found).To(BeTrue(), "Expected to find --config-text in scheduler deployment")
+				g.Expect(configText).To(ContainSubstring("prefix-cache-scorer"))
+				return nil
+			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Multi-GPU-vendor pooling via workload label propagation", func() {
+		It("should create InferencePool with default workload labels that AMD pods can match", func(ctx SpecContext) {
+			// This test verifies the multi-GPU-vendor pooling pattern:
+			// 1. NVIDIA instance with default scheduler creates InferencePool with default workload labels
+			// 2. AMD instance with no router uses spec.labels to match the NVIDIA InferencePool selector
+			nvidiaSvcName := "test-llm-nvidia"
+			amdSvcName := "test-llm-amd"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(nvidiaSvcName))
+
+			// Create NVIDIA instance with default scheduler
+			nvidiaLLMSvc := LLMInferenceService(nvidiaSvcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, nvidiaLLMSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, nvidiaLLMSvc)
+			}()
+
+			// Verify InferencePool is created with default workload label selector
+			ip := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, client.ObjectKey{
+					Name:      nvidiaSvcName + "-inference-pool",
+					Namespace: testNs.Name,
+				}, ip)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("app.kubernetes.io/name"), igwapi.LabelValue(nvidiaSvcName)))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("kserve.io/component"), igwapi.LabelValue("workload")))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("app.kubernetes.io/part-of"), igwapi.LabelValue("llminferenceservice")))
+
+			// Create AMD instance with no router, using spec.labels to match NVIDIA's InferencePool
+			amdLLMSvc := LLMInferenceService(amdSvcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithWorkloadLabels(map[string]string{
+					"app.kubernetes.io/name":    nvidiaSvcName,
+					"app.kubernetes.io/part-of": "llminferenceservice",
+					"kserve.io/component":       "workload",
+				}),
+			)
+
+			Expect(envTest.Create(ctx, amdLLMSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, amdLLMSvc)
+			}()
+
+			// Verify AMD workload deployment is created and its pod template labels
+			// match the NVIDIA InferencePool selector
+			amdDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Get(ctx, client.ObjectKey{
+					Name:      amdSvcName + "-kserve",
+					Namespace: testNs.Name,
+				}, amdDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			podLabels := amdDeployment.Spec.Template.Labels
+			for labelKey, labelValue := range ip.Spec.Selector.MatchLabels {
+				Expect(podLabels).To(HaveKeyWithValue(string(labelKey), string(labelValue)),
+					"AMD pod template label %q should match NVIDIA InferencePool selector", labelKey)
+			}
+
+			// Verify no InferencePool was created for the AMD instance
+			amdIP := &igwapi.InferencePool{}
+			err := envTest.Get(ctx, client.ObjectKey{
+				Name:      amdSvcName + "-inference-pool",
+				Namespace: testNs.Name,
+			}, amdIP)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"AMD instance should not create its own InferencePool")
+
+			// Verify no scheduler deployment was created for the AMD instance
+			amdScheduler := &appsv1.Deployment{}
+			err = envTest.Get(ctx, client.ObjectKey{
+				Name:      amdSvcName + "-kserve-epp",
+				Namespace: testNs.Name,
+			}, amdScheduler)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"AMD instance should not create a scheduler deployment")
+		})
+	})
+
+	Context("EPP port defaulting for upgrade compatibility", func() {
+		// The port defaulting for configs that omit port (pre-GIE-v1.2.0 upgrade
+		// scenario) is covered by the v1alpha2pool conversion (convertExtensionRefToV1)
+		// and combineBaseRefsConfig. Integration tests for the nil-port case are not
+		// feasible here because the v1alpha2 CEL rule rejects creating configs without
+		// port, and the v1alpha1 conversion defaults port to 9002 during ConvertTo.
+
+		It("should not override explicitly set EPP port", func(ctx SpecContext) {
+			svcName := "test-llm-port-explicit"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			schedulerCfg := LLMInferenceServiceConfig("kserve-config-llm-scheduler",
+				InNamespace[*v1alpha2.LLMInferenceServiceConfig](testNs.Name),
+			)
+			schedulerCfg.Spec.Router = &v1alpha2.RouterSpec{
+				Scheduler: &v1alpha2.SchedulerSpec{
+					Pool: &v1alpha2.InferencePoolSpec{
+						Spec: &igwapi.InferencePoolSpec{
+							EndpointPickerRef: igwapi.EndpointPickerRef{
+								Kind:        "Service",
+								Name:        igwapi.ObjectName(kmeta.ChildName(svcName, "-epp-service")),
+								Port:        ptr.To(igwapi.Port{Number: 8080}),
+								FailureMode: igwapi.EndpointPickerFailOpen,
+							},
+							Selector: igwapi.LabelSelector{
+								MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+									"app": "placeholder",
+								},
+							},
+							TargetPorts: []igwapi.Port{{Number: 8000}},
+						},
+					},
+					Template: &corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "main",
+							Image: "ghcr.io/llm-d/llm-d-inference-scheduler:v0.7.1",
+							Ports: []corev1.ContainerPort{
+								{Name: "grpc", ContainerPort: 8080, Protocol: corev1.ProtocolTCP},
+								{Name: "grpc-health", ContainerPort: 9003, Protocol: corev1.ProtocolTCP},
+								{Name: "metrics", ContainerPort: 9090, Protocol: corev1.ProtocolTCP},
+							},
+						}},
+					},
+				},
+			}
+			Expect(envTest.Client.Create(ctx, schedulerCfg)).To(Succeed())
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			ip := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) {
+				g.Expect(envTest.Get(ctx, client.ObjectKey{
+					Name:      svcName + "-inference-pool",
+					Namespace: testNs.Name,
+				}, ip)).To(Succeed())
+				g.Expect(ip.Spec.EndpointPickerRef.Port).NotTo(BeNil())
+				g.Expect(ip.Spec.EndpointPickerRef.Port.Number).To(Equal(igwapi.PortNumber(8080)))
 			}).WithContext(ctx).Should(Succeed())
 		})
 	})


### PR DESCRIPTION
cherry-pick of https://github.com/kserve/kserve/pull/5698/changes

https://redhat.atlassian.net/browse/RHOAIENG-70227

The v1 InferencePool CRD (GIE v1.5.0) has a CEL validation rule requiring port when kind is "Service" or unspecified. Configs created before GIE v1.2.0 omit the port field entirely, causing SchedulerReconcileError on upgrade.

Default port to 9002 (standard EPP gRPC port) in two places:

v1alpha2-to-v1 InferencePool conversion
combineBaseRefsConfig after merging all config layers
Both sites check Kind=="Service" and Kind=="" because the kubebuilder default is only applied server-side during admission, not during in-process deserialization.