### PR TITLE
chore(autogluon): update autogluon and its dependencies

### DIFF
--- a/python/autogluonserver/autogluon-all-requirements.txt
+++ b/python/autogluonserver/autogluon-all-requirements.txt
@@ -8,7 +8,7 @@
 # Then prepend --index-url and the kserve/kserve-storage file: entries below.
 # Note: hatchling and its deps are included for hermetic --no-build-isolation installs.
 #
---index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9/simple/
+--index-url https://console.redhat.com/api/pypi/public-rhai/rhoai/3.5/cpu-ubi9-test/simple/
 
 # # Local path dependencies (installed from this repository)
 # kserve @ file:../kserve
@@ -17,8 +17,8 @@
 absl-py==2.4.0 \
     --hash=sha256:89270ac19d667cec91fcf7793982b1afd9beb5d05714f2c57509ec78d7cdd225
     # via tensorboard
-accelerate==1.13.0 \
-    --hash=sha256:d384119b3d44376edcdc8af6bfcd930ff5addd758dcb18246a84d92d1edc2764
+accelerate==1.14.0 \
+    --hash=sha256:d39aacabf33ce9a0f9313e5d085752b1232db66a7dcdbd5a8cc0a64a86e8cd9d
     # via
     #   autogluon-timeseries
     #   chronos-forecasting
@@ -26,14 +26,14 @@ accelerate==1.13.0 \
 adagio==0.2.6 \
     --hash=sha256:4d2422959b43e3f109d1b89a65e0c4be2a44200dfd99395328aa7039b29d4af4
     # via fugue
-aiohappyeyeballs==2.6.2 \
-    --hash=sha256:36508a3b205c38102478f8ce09e69a1bb03b59d649632e009f9cc640da6df599
+aiohappyeyeballs==2.7.1 \
+    --hash=sha256:148c42ea64254eff51702e3643744a5d29e19f1cc7f1adcfb2289d7ac711ae80
     # via aiohttp
-aiohttp==3.13.3 \
-    --hash=sha256:21438003cd6ee66df69a2e16a4537e2aac12714925b28e9cdf64b0e431b83e7d \
-    --hash=sha256:3af11aed5a4d700f42ef4d3080fe741ff81ca98438a6a80e758031d7372860e5 \
-    --hash=sha256:3f9e4bf6c7c114a9e6527dee00c7364c5a45d925f4daa5e525024d9ecf49550d \
-    --hash=sha256:7085c908dfae6a1d8cac83bf98c3c09e04d67a4766d334cc95ed0c066ebb7deb
+aiohttp==3.14.1 \
+    --hash=sha256:bd49302b6aa79db20905429d539a0a328adf440c0a75508892ae9700d6318857 \
+    --hash=sha256:c958019fc4a4a4536be8308b5efdebb7b31b51dbcf9cc651e16d782ec404d372 \
+    --hash=sha256:dc7528950c7a168f8f70cfba05e112f4a857d658c9f0dfc854d6d4e9b17ecc23 \
+    --hash=sha256:f3c686257c0297a912e82e2582f6587b922f1e7b1e3ff0a2d3d3fb7093db545e
     # via
     #   fsspec
     #   kserve
@@ -41,8 +41,8 @@ aiohttp==3.13.3 \
 aiosignal==1.4.0 \
     --hash=sha256:f67c1242810c1da35afc04f8fe6057d1f133fa581d32ecc4c841d08134436218
     # via aiohttp
-alembic==1.18.4 \
-    --hash=sha256:71f1ba8af317c88248c49371a87749eef7991392609abc8ac8a2ad1074ee6149
+alembic==1.18.5 \
+    --hash=sha256:0f98f90659630b57854091690f22571e6443f39ffd6e60aa6a12f57da1c667d4
     # via optuna
 annotated-doc==0.0.4 \
     --hash=sha256:1ecb2803f2d35e57ba03d74245d9ece70ffce1552a51d1ab1d2b439d791e5086
@@ -52,8 +52,8 @@ annotated-doc==0.0.4 \
 annotated-types==0.7.0 \
     --hash=sha256:d31d6f386f3ecd6cdca12274844b969c3f9c90d15ebef7774f2eb34857108758
     # via pydantic
-anyio==4.12.1 \
-    --hash=sha256:dca02e926e3a7108eb7ad78cca5ec87d400583f7a400d779f79239b51ca0df9f
+anyio==4.14.1 \
+    --hash=sha256:7b1919965ee5094a3cf8b0c371749b59b5835293055e51ab23a4a45bca1d3fab
     # via
     #   httpx
     #   httpx2
@@ -71,37 +71,45 @@ apswutils==0.1.2 \
 attrs==26.1.0 \
     --hash=sha256:72a7cd6c5cd0ba459eec87d0cff40ba06839196b8355a01450ea1db9f6ab6a3d
     # via aiohttp
-autogluon-common==1.5.0+rhaiv.3 \
-    --hash=sha256:275dce3a878cd2f599e56e9492ed5654c68ebbe2e230241df954b45354e3605e
+autogluon-common==1.5.0+rhaiv.4 \
+    --hash=sha256:05061d70230b005d29980aeaf98303430b3ae1705b56313c60d942063df16001
     # via
     #   autogluon-core
     #   autogluon-features
     #   autogluon-timeseries
-autogluon-core==1.5.0+rhaiv.3 \
-    --hash=sha256:0bf49a1458ed19dd8ff555c556f83ece57798601e7411a3783d8eb368dd08cef
+autogluon-core==1.5.0+rhaiv.4 \
+    --hash=sha256:6803d49d894b62d89f3d5fb622de2eadbedbd0a13b90ca720de7a48494ee5c9e
     # via
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-features==1.5.0+rhaiv.3 \
-    --hash=sha256:f8babe97648ca9fc0e03fbee4ebcbe562b1eb3cadd77a36116bcf3fbd71e5b82
+autogluon-features==1.5.0+rhaiv.4 \
+    --hash=sha256:c57c76765980d2e440256dc533dce7688f18aa26d318c79f3da5985e48980809
     # via
     #   autogluon-tabular
     #   autogluon-timeseries
-autogluon-tabular==1.5.0+rhaiv.3 \
-    --hash=sha256:5c81be0bca755de785bf8d6f5d08d1c8fb034189f6a25ded5a376e1a5b0abbcd
+autogluon-tabular==1.5.0+rhaiv.4 \
+    --hash=sha256:6d6bd81a9bbd0c4e072a31a61e89889c5dc3bbc5083018ab58fefeacedbef476
     # via
     #   autogluon-timeseries
     #   autogluonserver
-autogluon-timeseries==1.5.0+rhaiv.3 \
-    --hash=sha256:616025bc2d524772ebbfaecdbe786a07a76c645a02dc2595ab4c32309b530602
+autogluon-timeseries==1.5.0+rhaiv.4 \
+    --hash=sha256:60085f6af0f94e515bacdf6aed7fbe815b65e8c2fcaaf0dcce87bde64adb9895
     # via autogluonserver
 azure-core==1.41.0 \
     --hash=sha256:c48efb0ab2d42215cfb53cb348d5fe4a1edbf90d6da90c1a2060b665dfd956a4
     # via
     #   azure-identity
+    #   azure-storage-blob
+    #   azure-storage-file-share
     #   kserve-storage
 azure-identity==1.25.3 \
     --hash=sha256:ddb57aa5e631f75dfad74a87841dc1b6ba48f0c4f128cd82f493de456229e344
+    # via kserve-storage
+azure-storage-blob==12.30.0 \
+    --hash=sha256:81248dc1d9b50824e389610139ff547b1bb25c529c3c1ae9814d59c84a9e2b14
+    # via kserve-storage
+azure-storage-file-share==12.26.0 \
+    --hash=sha256:fe17c90215048d210d4f746596cc366ec15c22bc3b69adae534596258bea1eb3
     # via kserve-storage
 beartype==0.22.9 \
     --hash=sha256:7e0e03f04547689224dd1fb5471f9f0080426e8227b34a6d7d1eefd4c190a6a6
@@ -115,14 +123,14 @@ blis==1.3.3 \
     --hash=sha256:80c8d5f0e51831694734105d9a047193aebf7918c05c865923abe52b56785910 \
     --hash=sha256:c1ae9d426e7345eb936fda81639a7dddcaaf479bffc948da7c0c4018fe18103b
     # via thinc
-boto3==1.43.36 \
-    --hash=sha256:d55dd5d6841ae3819929a7f35402f8d22d43b2307da69dc48e33cb2f93f57127
+boto3==1.43.39 \
+    --hash=sha256:7f368828181b2bddf94344c71f280b5bcffee9311c4fe68111fe08ce21c42b83
     # via
     #   autogluon-common
     #   autogluon-core
     #   kserve-storage
-botocore==1.43.36 \
-    --hash=sha256:f390e431035d38170d0bbd987e8948562f6e8383b08a7dc72a56f16efee0f5b2
+botocore==1.43.39 \
+    --hash=sha256:3286d596e24789d34865d392215a4ab41e35d155d706104f866419b02b66b619
     # via
     #   boto3
     #   s3transfer
@@ -148,12 +156,15 @@ cffi==2.0.0 ; platform_python_implementation != 'PyPy' \
 charset-normalizer==3.4.7 \
     --hash=sha256:29d94e888271160a8b8c2a465d62777b7f0c2a5c056a57b1c47dc60765eea275
     # via requests
-chronos-forecasting==2.2.2 \
-    --hash=sha256:db9adbb8344d5a21f6077fe123eac8105f8159f346405bc6444f68e79a6709f4
+chronos-forecasting==2.3.0 \
+    --hash=sha256:a8fe5dfd6435dbeeb60f3bec7b6452fa9ba570962e7f2e776e2323e9d1ed0d27
     # via autogluon-timeseries
-click==8.2.1 \
-    --hash=sha256:d7f398e063a6b655be2ac2374b284b2eec55afed7384f092ea5ce402672faf67
-    # via uvicorn
+click==8.4.2 \
+    --hash=sha256:368d4af9976de9fc5efc4d8a26c64d23c187c21a2eba9336254832d466dd6198
+    # via
+    #   huggingface-hub
+    #   typer
+    #   uvicorn
 cloudevents==1.12.1 \
     --hash=sha256:66ed12f538b3a041dcb91b0c92f77760c7ea547e8f078bf4bea6197f861afcd3
     # via kserve
@@ -172,7 +183,6 @@ colorama==0.4.6 ; sys_platform == 'win32' \
     #   click
     #   colorlog
     #   tqdm
-    #   typer
     #   uvicorn
     #   wasabi
 colorlog==6.10.1 \
@@ -206,6 +216,9 @@ cryptography==49.0.0 \
     --hash=sha256:8e320bcb06edbda1999f4f992caf8d1af2a9f6b846d5d4acc8584c120779308a
     # via
     #   azure-identity
+    #   azure-storage-blob
+    #   azure-storage-file-share
+    #   google-auth
     #   kserve
     #   kserve-storage
     #   msal
@@ -225,11 +238,11 @@ cymem==2.0.13 \
 deprecation==2.1.0 \
     --hash=sha256:337b05e2af07ef5fba9e4fa4219fb3d549dde2985eaff6fd70aefa02c32c498e
     # via cloudevents
-dulwich==1.2.6 \
-    --hash=sha256:5189d47633ad42671511696ac39d4f9c158d48c106db10d06e54f367810f008f \
-    --hash=sha256:6f02730f7f61ad202e68e5e4cb9fadf9a686b5a27b903296157a7efb2633c858 \
-    --hash=sha256:ce02fd83b168b8f2f8457e701a0abdf74a9f37459a984e33d2b7aa8bf49b106a \
-    --hash=sha256:fec6a8e6874b40322026d72eea140d79bdc6ce8eb937d52a12ba00f4766c9d54
+dulwich==1.2.7 \
+    --hash=sha256:048f35d098ad1e08c98e4338b1a33652f1463fbc5e2020c235b503970c5ab0b6 \
+    --hash=sha256:13e69050ebbeb8a328d3c59249c549d9ccc7d61a1b019b3e20fed0067ed27711 \
+    --hash=sha256:1871a5e09c9876cc48c87522bcf69915821d3f696edd3ccc8eff731d03ad739f \
+    --hash=sha256:de814ce4fe1b6478febd5cb050e8a634ffaca6e8809ce5c622169ef549f43825
     # via kserve-storage
 durationpy==0.10 \
     --hash=sha256:7f09ea3ef8ceecbade4314c9dd1e9269e77bde08f3569802ae1606d6f6775efa
@@ -242,11 +255,11 @@ einops==0.8.2 \
 fastai==2.8.7 \
     --hash=sha256:807e2f12314d88cf73e04bd5aa56b09b3894de1ceadfd0147dd06d27d082bbb5
     # via autogluon-tabular
-fastapi==0.136.3 \
-    --hash=sha256:691af4cfa72721b15151732f9e7b5ed3998fa4553c1664519a8766c4f509690e
+fastapi==0.139.0 \
+    --hash=sha256:2168ec8cfcd11399fb63fd49903a53e0a49aa5f178a90dd72ee6cc482d98c3a6
     # via kserve
-fastcore==1.13.6 \
-    --hash=sha256:86e2442b8c852405a8d6d66ed9d6d14891c7d50ed297285d1ba8e4c257b8b60b
+fastcore==1.13.8 \
+    --hash=sha256:41d386381ddf9fff767abe91b9484ffc687bb6edd94563ff942b99d7a1cb62d1
     # via
     #   apswutils
     #   fastai
@@ -274,7 +287,6 @@ filelock==3.29.4 \
     # via
     #   huggingface-hub
     #   torch
-    #   transformers
 fonttools==4.63.0 \
     --hash=sha256:abcf2674eed3d941d1671f966f3bebbc42b4906b0477c3a6a0e8c05c6669efa4
     # via matplotlib
@@ -286,8 +298,8 @@ frozenlist==1.8.0 \
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2026.2.0 \
-    --hash=sha256:49b6a55beff15391f0263932bb504812a5153780a4560c702de3662fd6a648b5
+fsspec==2026.6.0 \
+    --hash=sha256:9a76dd86f01d5e2034c8192684e131d070de32d4d9d76843821351819e6ee2ef
     # via
     #   huggingface-hub
     #   lightning
@@ -300,13 +312,41 @@ fugue==0.9.7 \
     # via
     #   autogluon-timeseries
     #   statsforecast
-gluonts==0.16.2 \
-    --hash=sha256:38c1036c4074f48e816c1b2180fd8d6b46ab8e03262deb8430ea09eb08f50acf
+gluonts==0.16.3 \
+    --hash=sha256:98d72abffe165f7501114e5ff6be009e3adc56708af4ef087229b052e96c2a0d
     # via autogluon-timeseries
-greenlet==3.5.2 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
-    --hash=sha256:04c9442657eb4f06280534d63ba1ff974fc559884c3abb6682c92e4b843fa149 \
-    --hash=sha256:1be8d602a6d5379bafa91f3a704cd71b2f966b324ef5e008ed199474a1f413e0 \
-    --hash=sha256:395cd79488fb33ac91536d4c33ec290bac86e6adc3a019c962d76ce4c2544ef3
+google-api-core==2.31.0 \
+    --hash=sha256:2975c76ecb910406ff6f71c62ed09848d0db421b27986413c448cb8766fc827e
+    # via
+    #   google-cloud-core
+    #   google-cloud-storage
+google-auth==2.55.1 \
+    --hash=sha256:ac65513eeeb2813444f44744b513a087303eeaa34e9296f0fb151503196635c5
+    # via
+    #   google-api-core
+    #   google-cloud-core
+    #   google-cloud-storage
+google-cloud-core==2.6.0 \
+    --hash=sha256:2b0e1f09be56b927f3cb231052fea35805cb74f5594235a927eb519af1c78b17
+    # via google-cloud-storage
+google-cloud-storage==2.19.0 \
+    --hash=sha256:ede161ad46a46f6a94f12f19f1794bef73a7600dcd4d68c1999511e277e8e6da
+    # via kserve-storage
+google-crc32c==1.8.0 \
+    --hash=sha256:3152fc17ef99180190f8e14a850fddc3ab8c3911b2d92d130e7219c79dfe7d7c
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.10.0 \
+    --hash=sha256:161f9c50277e40f8b161fd25f0a989ada00a9b6a52dab45eb4569df5d873d09d
+    # via google-cloud-storage
+googleapis-common-protos==1.75.0 \
+    --hash=sha256:371cd0ca347d6b331c0f70fbbf7aa5cbbba6092d91d27c9bbfab7701a1b6612d
+    # via google-api-core
+greenlet==3.5.3 ; platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64' \
+    --hash=sha256:396eb576e8312ea7cc8c7691ea935f499fe440bf1b123936580ea672f7c11d6d \
+    --hash=sha256:b58b912e1e66b8276e32a8e9e6437884537f9d9dae8a53cf4457aba31b073547 \
+    --hash=sha256:e7bf99427ac4174c765563c6c8d5886d672d830237be3f7efab210919efc7cdc
     # via sqlalchemy
 grpc-interceptor==0.15.4 \
     --hash=sha256:cea9af82bdf3eda84289369c447f8aef180b7dc6f26efd56625f0bbe9b908fcb
@@ -345,8 +385,8 @@ hf-xet==1.5.1 \
 httpcore==1.0.9 \
     --hash=sha256:fc0ea63671089523efc6fe94ec49d0b10c9660460cbca6172fc972c1c5f9c0ac
     # via httpx
-httpcore2==2.4.0 \
-    --hash=sha256:116aa20acec704d5888e6fccab25754e754d4e9e25615532950d9f22fff2f1eb
+httpcore2==2.5.0 \
+    --hash=sha256:1e8550e99da4297cb64d0cd5dd797c11a736a11f6fcbd8ffec350a9a85b39a27
     # via httpx2
 httptools==0.8.0 \
     --hash=sha256:0d87c67fcf648e1b77acdd1eb0178be0a1252e3aeeec5985a9a7a87ae63dc05f \
@@ -357,15 +397,17 @@ httptools==0.8.0 \
 httpx==0.28.1 \
     --hash=sha256:40b3fef8650d88ced417b05b236427596a6da9117b0f64ef5b0a5d548d20addb
     # via
+    #   huggingface-hub
     #   kserve
     #   weasel
-httpx2==2.4.0 \
-    --hash=sha256:4f70a0b6fb115025547e8d844897dda9b341b4034e9fe00edd68728810f28f77
+httpx2==2.5.0 \
+    --hash=sha256:78cf66523b7294f6cd2f18e8a04f0b46b2fec6bdb294c464ba111ddd44953129
     # via python-fasthtml
-huggingface-hub==0.36.2 \
-    --hash=sha256:9dbca7484c9269e61e6e4a8202b38c00654c9a68843ccc201049a6abc38cf412
+huggingface-hub==1.21.0 \
+    --hash=sha256:2bb8c02ad24b679f7988c5f1cb13286ef7e4770feb148b3cc4f4eb26a8c72b31
     # via
     #   accelerate
+    #   kserve-storage
     #   peft
     #   tokenizers
     #   transformers
@@ -377,6 +419,11 @@ idna==3.18 \
     #   httpx2
     #   requests
     #   yarl
+isodate==0.7.2 \
+    --hash=sha256:f96dfe71d29abf9fdcdb63184bad8e0081b20f46312a6a759cb4e13b6958738c
+    # via
+    #   azure-storage-blob
+    #   azure-storage-file-share
 itsdangerous==2.2.0 \
     --hash=sha256:d6f709c1a264254c2520d68019cfb282ac07c07ba7871cad79831df685d0a185
     # via python-fasthtml
@@ -402,8 +449,8 @@ kiwisolver==1.5.0 \
     --hash=sha256:b2a750282f35ba58b1069ccda30fd0e6001c3413e8dcaf62c24aa48f2cb7a62e \
     --hash=sha256:cb2022c8033491fbbc318c49667f122732a4edd4744628f55034728ee54d2552
     # via matplotlib
-kubernetes==35.0.0 \
-    --hash=sha256:92968784d96be87c11ed242ac7bc0ca1c41f51dd6c6b4060259d928dfa717326
+kubernetes==36.0.2 \
+    --hash=sha256:48617d55c4fa6ded5f35aead8ccacc4cc448b2272feaeeb3f16b703d65704b28
     # via kserve
 lightgbm==4.6.0 \
     --hash=sha256:3231a268fdd6584a41dc2ecdaf7f175e1556df1c6f79cbd4713ef67ca9a52588 \
@@ -420,15 +467,11 @@ lightning-utilities==0.15.3 \
     #   lightning
     #   pytorch-lightning
     #   torchmetrics
-llvmlite==0.46.0 \
-    --hash=sha256:2e98ec7669c47e20b1f938bfcf3a58185b1678da57aad4d5999f7df3f79d61ca \
-    --hash=sha256:88ee1c271f070232b9ee5f5796c740db24e38d48b9eb043c9ec8a8f795047439 \
-    --hash=sha256:89cfaa62388eb5e29ecd7ccc27633221621bb47e00d5ec72bc6904574b6f8210 \
-    --hash=sha256:94fe8043bd80652412bf115e05041ae16c445bd8e15918843d952ed806cf1fcb \
-    --hash=sha256:b6585b9fdf2867c967bf7263558a9762795d21fa8f5d510880d1485adb5aa9f4 \
-    --hash=sha256:c49a9cafffe941ba60fc3b6fa3afffde477c406f57761fe70c3da28971cf7e48 \
-    --hash=sha256:cbd147fef4ada4abc760b23a5717db7a682ad76e4b34933019746b19d8d5006c \
-    --hash=sha256:f9f61336dc1266e4d92a81d0212158dcd0d6c0f68cbb80dee66d2fee5e82e18f
+llvmlite==0.47.0 \
+    --hash=sha256:2b401d1cc37b411faad88c316b743f5a86a60b6c36227119049f73442fcb4a3d \
+    --hash=sha256:3d621471747bdfc7e45d1bb212561f5ce04cfe5d0f4a293f9b280ac5c82c062b \
+    --hash=sha256:5776dc25a659ab6ae49dd20e5d4f0cf5448186f1ada5cf741e96de85ae1d903a \
+    --hash=sha256:6b9e6071ee9c592bbbd36783fe4a1bf2d714570b672067d75f02d4492fe6ce09
     # via numba
 mako==1.3.12 \
     --hash=sha256:39aa737c9633f559da1068b3791b5b20f5c25567b0c19f566bdfab82d7129705
@@ -501,20 +544,20 @@ networkx==3.6.1 \
     #   autogluon-tabular
     #   autogluon-timeseries
     #   torch
-numba==0.64.0 \
-    --hash=sha256:578cf08b5bc34b2f28789a2354a05fbce8a43ce31181132d4d24e4fd316efb5f \
-    --hash=sha256:9280e5929681aee57c62d5417bc99ee1b999d9c2cc483ffb905da1f67b4e017e \
-    --hash=sha256:97da30494e31b68230b78a3f2d06457595ed5907903bf86b2977009fc37ac1d0 \
-    --hash=sha256:b4c718620a3018d867f0c8cfc27ca388f6501999f59b1f1c163e7ca2629587e0
+numba==0.65.1 \
+    --hash=sha256:644d153cc9d3a57a0189a92ae473f835b0f746f202f7faab12192016545503b2 \
+    --hash=sha256:97cbbec2ebaef86326e170b0548833044cf8d424a86d4f36da466711ee089944 \
+    --hash=sha256:e94cb978702a0b043958f2bd2f1e5330b09c14cdaf4627a2f5d3d00a28083945 \
+    --hash=sha256:f1ac1e7a5def5cef68222849e080aeda7b047bd68959f5a3c9b98088efd5ad9d
     # via
     #   mlforecast
     #   statsforecast
     #   window-ops
-numpy==2.1.3 \
-    --hash=sha256:134e2c7657bd3bd2f54ac156c3ac9618f8215a6a4fb93927b552251bc8a75fd7 \
-    --hash=sha256:3a8a1a7b772d4e6d8f977109d235f31c6a1ecce82591f54035cec44387f3d3c0 \
-    --hash=sha256:fac47448276d1d51048bc87d1a983cd8d1601af9e5aa9afc32aa9459ae1632ae \
-    --hash=sha256:fc99c458bc8d644e5461ae5d900abce9f8576268d663bf3f2b2cb24724eb380b
+numpy==2.3.5 \
+    --hash=sha256:550e0e9ae69f20d4b8a47c518dafe0101f48c39c7f63ca6f6fd6b774245a828b \
+    --hash=sha256:5fb8f350b6b7a3a5fe00e12e5510294512f77ce3c10275fd14b0b6ed304ef080 \
+    --hash=sha256:927205c8882f7a53543a8fc5b13fcb05771d6bfff35e06daf8030e57549cc7be \
+    --hash=sha256:a08c6c26c26d7530d09ac93bc177593958c2e3ce4a9b5750c14a80329cca157c
     # via
     #   accelerate
     #   autogluon-common
@@ -554,8 +597,8 @@ oauthlib==3.3.1 \
     # via
     #   python-fasthtml
     #   requests-oauthlib
-optuna==4.8.0 \
-    --hash=sha256:3bcde83ba91cac6770c6b935ab962f4bcc954d5c2926a8c6a185b8d7334522c8
+optuna==4.9.0 \
+    --hash=sha256:c673e5fee9f124b5ea7daedd883b0dffb5a8e8ef19ce17bb2b9e048878a92322
     # via mlforecast
 orjson==3.11.9 \
     --hash=sha256:21ad5305e765b982e46b044165f8a37f2dfc29f2986a54b3ad5c4c7757b5480c \
@@ -565,8 +608,8 @@ orjson==3.11.9 \
     # via
     #   autogluon-timeseries
     #   kserve
-packaging==26.0 \
-    --hash=sha256:bc63e159c7f7120596c4318a4de6c8288c34a1df98656b357c2d277739da4b30
+packaging==26.2 \
+    --hash=sha256:7c418e01ce14b2bfd2cbf95e6d0a2b1278b711cd84527100f02b0966f08cc4a5
     # via
     #   accelerate
     #   deprecation
@@ -602,6 +645,7 @@ pandas==2.3.3 \
     #   autogluon-features
     #   autogluon-tabular
     #   autogluon-timeseries
+    #   chronos-forecasting
     #   fastai
     #   fugue
     #   gluonts
@@ -614,14 +658,14 @@ pandas==2.3.3 \
 patsy==1.0.2 \
     --hash=sha256:6b66345ff8483da43877a53d0329ae259839481128cb662e748d0908884f922b
     # via statsmodels
-peft==0.17.1 \
-    --hash=sha256:c232245f26ebffcaf9fdb871fb57fdf93172c97a2315b4da280ac842c0aae6da
+peft==0.19.1 \
+    --hash=sha256:f535ba967638601280a0d00480242ff013e14b5f9d8596a2c3ffa353ae5f159d
     # via autogluon-timeseries
-pillow==12.2.0 \
-    --hash=sha256:0fff098f48b7cce240acc99b967c66f590d5a1e94a17b3a12e9028dd8f624325 \
-    --hash=sha256:a6e4ef4ffe4ff1e11d592b6196ef06f0e04e4bf85797a42019facc66aa587adc \
-    --hash=sha256:b61d159c77c5b9d0f87c105916d572b3b80a9cab8619e8ca52f83683edfeeac1 \
-    --hash=sha256:b756b70ecc7e9de6329181e096051ac92c1c2694055cc2a4e120bd5f442ff4fc
+pillow==12.3.0 \
+    --hash=sha256:4a904ef7f3765fc818c3a483529ff04147e97cc0390f9eec5edd30cae497fafe \
+    --hash=sha256:5762ef56cdceff2319ac80ed92150106a0bf51ec2eea15226f44c9d983e7b916 \
+    --hash=sha256:65a30ac6a91ac6d2d08c73441c8fe69653d0d818312b18d1dc86ee8932529cec \
+    --hash=sha256:bb4f92e67999c0820fd8a9f959f0dce3b0b0dcb8144d47aa7a1432183e7c4c98
     # via
     #   fastai
     #   matplotlib
@@ -640,25 +684,31 @@ preshed==3.0.13 \
     # via
     #   spacy
     #   thinc
-prometheus-client==0.24.1 \
-    --hash=sha256:3cba6f12a41b9a65f307d8ee9685759fd58352d58088939b60c0a2618e699e18
+prometheus-client==0.25.0 \
+    --hash=sha256:34577aeee817238adf900bebb60c63697fa70d15d8f9e1c6984729cce45fb10f
     # via kserve
-propcache==0.4.1 \
-    --hash=sha256:592720ed230b7c5fd2137d6dfcd483e856c5ffba4f2ec65f119df696190e70c3 \
-    --hash=sha256:74d3401abe4e59fb9de6a2b1951f0a6e73321da05096a1e578a6e2311ab26204 \
-    --hash=sha256:846626915d5125527d1aec396e74c3ff2644179752698453a63ee7b651f20b7b \
-    --hash=sha256:d2dc9b0baa6aedb2b462dbea35040695b466101c073c125616dc19c6199d4bbb
+propcache==0.5.2 \
+    --hash=sha256:37db9ae1c467dce775f463680d1bf110ec3237f08f5bee36fd60c399344fa617 \
+    --hash=sha256:54bc48bc3831e3961366b03767df820e5e2b94a4713cbf1df90227964217e66d \
+    --hash=sha256:b2159ad520c71e28c53e8a62ec22129d09367655a79316af1540cced34b4de0f \
+    --hash=sha256:c3d7df883bd7a7d3ca589088e92943521cc11a0bea9c73c2f49f862ac60da337
     # via
     #   aiohttp
     #   yarl
-protobuf==6.33.5 \
-    --hash=sha256:8082790b279da277dbdd8f624764c2076cddb84ac9cc30cde2369f6e667063ae \
-    --hash=sha256:b626bcaaf1809381ca18ac7fbbc2a87270a5a502f75f636799361cc6537b4b6a \
-    --hash=sha256:cc358141ab2986dcb676f0d5ddbafd8fd7f5bbcb071e21be307bd2ac998bf1d6 \
-    --hash=sha256:fb4bbd534874cace05dfed5e071a0fd3dcda3cff0f1c01e99dcc78740a573856
+proto-plus==1.28.0 \
+    --hash=sha256:c83edf58f7288c50bd6c830fb50ff70841ca622cd6611b918451ce2b7336f295
+    # via google-api-core
+protobuf==6.33.6 \
+    --hash=sha256:09200f54359e58520e2d09bc8cb2fe14f15cdb493f8b0d9e2c86da3da5be07e4 \
+    --hash=sha256:2689490d83100ac29114a0d76af57130fa08937abb068815057caf7b55702cf3 \
+    --hash=sha256:3eb1ade13a945a4cc3803f9a793ed22627f9bb6b577f6548022f9f1acdd2fcd6 \
+    --hash=sha256:ad3345d512d57367d0a9753f679f8056d09253783f215c136e19f6b0242a0997
     # via
+    #   google-api-core
+    #   googleapis-common-protos
     #   grpcio-tools
     #   kserve
+    #   proto-plus
     #   tensorboard
     #   transformers
 psutil==5.9.8 \
@@ -684,11 +734,15 @@ pyasn1==0.6.3 \
     # via
     #   kserve
     #   kserve-storage
+    #   pyasn1-modules
+pyasn1-modules==0.4.2 \
+    --hash=sha256:6b1010138365a6fc22f4efd32edd504ec3f538e1ac3d1947ba9f7821ef15ef6c
+    # via google-auth
 pycparser==3.0 ; implementation_name != 'PyPy' and platform_python_implementation != 'PyPy' \
     --hash=sha256:c2e6198bf8dc97ba19b5f42d9d0e08d5842ffb775e0e208b150080dcf423396e
     # via cffi
-pydantic==2.12.5 \
-    --hash=sha256:b64a2f86c66e61a4a8f3e3cb405cc87fe12469a1c4557ce1fe74f26e96e47088
+pydantic==2.13.4 \
+    --hash=sha256:1a3d4d45204182df30dbd68890bdf1becec13f689075099866dd4bdf06b04371
     # via
     #   fastapi
     #   gluonts
@@ -696,11 +750,11 @@ pydantic==2.12.5 \
     #   spacy
     #   thinc
     #   weasel
-pydantic-core==2.41.5 \
-    --hash=sha256:29a675b8ca3ccf804cce3a91095110d1741b6c62bf6690b0df5cc8a9ef08b056 \
-    --hash=sha256:62c65c46fa3fcf4290e3273e19e3fb762dd3135af4bd4aa59dbbf8715ca5807a \
-    --hash=sha256:b43916e6a561935162448b3ab0c3b87f177a22625da2d467f5546ccd21c5badc \
-    --hash=sha256:e76ab570fb017182f2fa1fc527926233b9c2e75a60471aa4506004c843983f0c
+pydantic-core==2.46.4 \
+    --hash=sha256:284014bde1fe354f45589df5638b38bc1bee9634a8b0bc9a7364f820c7c915b9 \
+    --hash=sha256:2be22610c7312f3232c539a9872c1c7217f0167093e9f7ff38ee79a072528f69 \
+    --hash=sha256:38235509e8f37596cc39453972c1a9b200287d92a98eb2a7c92d9708a98eec49 \
+    --hash=sha256:bbc9884932978a8f52c59aac4a0a273c8e514d303fd040c38b0436b37e57ed33
     # via pydantic
 pygments==2.20.0 \
     --hash=sha256:14c06510dc5a2dbf9d83a85463d229907d0456e167a3752d361e6cd1cbfd1152
@@ -723,11 +777,11 @@ python-dateutil==2.9.0.post0 \
     #   matplotlib
     #   pandas
     #   python-fasthtml
-python-dotenv==1.2.1 \
-    --hash=sha256:9a61d5ab192d9d8f9de53162fca3bbed25aa42b994d0fdd47caa59f784793887
+python-dotenv==1.2.2 \
+    --hash=sha256:b380203de11ab7a5b422fa6f9f377fe1ae1e1daa8559474a0518b6ca10f7aec5
     # via uvicorn
-python-fasthtml==0.14.3 \
-    --hash=sha256:20e8bbfbdf31c6288ad5786f86f0d00b3ea6b475c3c02eeb097e7b4ef8431582
+python-fasthtml==0.14.4 \
+    --hash=sha256:33a4005c6110ad78368c6bd337d1d58279dcecaffa562df5749f08c7486c1496
     # via fastprogress
 python-multipart==0.0.32 \
     --hash=sha256:61e4a190f7cd947a7aebc96a97976e628210851d66f7a25a6ddc3dab2305e6b4
@@ -758,26 +812,26 @@ pyyaml==6.0.3 \
     #   pytorch-lightning
     #   transformers
     #   uvicorn
-regex==2026.5.9 \
-    --hash=sha256:10dffee7540d4ef59ede26661bd50ac117422abbe628f15f806be02f50ff7fe1 \
-    --hash=sha256:807a2846f13470bf98da27991b7cfa0c69e7dd841e18741b74070f0abadbf755 \
-    --hash=sha256:e365aeca234d8c18ec2dd47ea3166766d815ec44f82fecfdc5a446961af0a3b4 \
-    --hash=sha256:e7506a9c89923515e7d170bc2af6a0aa1baa9fe45f5047ae9a33c4dab2079d1f
+regex==2026.6.28 \
+    --hash=sha256:0a446b8df5e25136bc4593e7fda87a6e9fd90c39f6590b17f956a4a33f06befd \
+    --hash=sha256:61e0265249e21c085a43eae5697f8af4f5de2e2bb618d84a2a26cb74b835291d \
+    --hash=sha256:6b66ade7516653a196b9fe8df143287d2db5ab967c994568b02be4cee7a59684 \
+    --hash=sha256:cb5ec8de92e359fea1bd7178cd4a19e00d57739be51016c3d78ad8f5a5735de0
     # via transformers
-requests==2.32.5 \
-    --hash=sha256:d183c52a0977268ea84b092f747d88f7b914a87ecbac34b8d40dd6dbe65d835e
+requests==2.34.2 \
+    --hash=sha256:ea6708de2da329a533299949db29fca0e3f7e3135068ad5171a28d07a9687631
     # via
     #   autogluon-common
     #   autogluon-core
     #   azure-core
     #   fastai
-    #   huggingface-hub
+    #   google-api-core
+    #   google-cloud-storage
     #   kserve-storage
     #   kubernetes
     #   msal
     #   requests-oauthlib
     #   spacy
-    #   transformers
 requests-oauthlib==2.0.0 \
     --hash=sha256:a97b432a279e3353fc512189927bfd2a2ff168b05d66a7600966e39b24efdcbe
     # via kubernetes
@@ -789,11 +843,11 @@ rich==15.0.0 \
 s3transfer==0.19.0 \
     --hash=sha256:655d6499f27e1ada64bc74d7bbf10360a6683f192245e6c5e458df9d230b5d42
     # via boto3
-safetensors==0.7.0 \
-    --hash=sha256:577edcd58cf370e60418cb5b2dc3687a25ed9061da9a900ed77d10340446e014 \
-    --hash=sha256:5b339660c98d1b096c6bda650e5d5e308cbbfab27c216d84df9671836d01e390 \
-    --hash=sha256:bcc9be1bd4c05f11330afb4d1c2d9a3b5d8c4e87452ebb2c83ece93ce168e91c \
-    --hash=sha256:d6d09a4c7bf5990d20c3486f2a77ce93cb7a5aba827a2b3ba83fa605174c22a3
+safetensors==0.8.0 \
+    --hash=sha256:23e3a3c88c19ad1a2d282a4eb04a84433aa406daeaa4e1d8f49b0123cafc9e62 \
+    --hash=sha256:800d4a5cf3320f0c0b49dfb7b4ec6cfe9a5e735b33b8254a74d5a2e452dc4408 \
+    --hash=sha256:ae8e482791a7348f972072ac995368904d8fe58ee62c7e410ec2b6b03cc76cab \
+    --hash=sha256:b903354cbf8d3db3818b1942f9d39b0e713b5a93bd3790502412d2b01ebc217e
     # via
     #   accelerate
     #   peft
@@ -807,7 +861,6 @@ scikit-learn==1.7.2 \
     #   autogluon-core
     #   autogluon-features
     #   autogluon-tabular
-    #   chronos-forecasting
     #   fastai
     #   mlforecast
 scipy==1.16.3 \
@@ -849,8 +902,8 @@ six==1.17.0 \
     #   kubernetes
     #   python-dateutil
     #   triad
-smart-open==7.6.1 \
-    --hash=sha256:e7dd8288da3d0ed9291472ae4aa06dd1f76223c26c0e907b0b7c25002717d27a
+smart-open==8.0.0 \
+    --hash=sha256:fe571f1d98d54fc4c7237c09b02bf1fcaf6aac90f50abe8fc441046ddb13f246
     # via weasel
 soupsieve==2.8.4 \
     --hash=sha256:44c0800eab5e3d194c01a74a9758a71ea555698bf13a13163ced21a69626d8f9
@@ -907,10 +960,11 @@ statsmodels==0.14.6 \
 sympy==1.14.0 \
     --hash=sha256:6cf6a1e379dbba75ca560e2cbd4394144f9e7e7335ee1be872c224f004eeb172
     # via torch
-tabulate==0.9.0 \
-    --hash=sha256:ef9bca44af03c29dcd9dc0c10671af4062fb3a3aa83f16119bd7a1e98139a228
+tabulate==0.10.0 \
+    --hash=sha256:ab130f2db33194496db41f780bb6723620399a36b30dde286264d80b5505a60f
     # via kserve
 tensorboard==2.20.0 \
+    --hash=sha256:8af05733701866addd2c258d20fce95a1d3b14736ee22bf3b2af81ec32ef7e9c \
     --hash=sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6
     # via autogluon-timeseries
 tensorboard-data-server==0.7.2 \
@@ -972,8 +1026,8 @@ torchvision==0.26.0 \
     --hash=sha256:d979cf1e7f240fbeca6cc112f7b81682dcfadb9377e80a46b3f0de7150f1b740 \
     --hash=sha256:fa92f98a32083ef5b1a5671aec3b59b2061d8827c830438baf6fe1b020d6c782
     # via fastai
-tqdm==4.67.3 \
-    --hash=sha256:9cdaa3ef8944e8a64e15f580ac86aa264affc2da130173fa2f1893468a4befb7
+tqdm==4.68.3 \
+    --hash=sha256:c38bf26fceea384cfefee552b1e0e947fcee7fdba0905013330f7a2d945c34b2
     # via
     #   autogluon-common
     #   autogluon-core
@@ -987,8 +1041,8 @@ tqdm==4.67.3 \
     #   spacy
     #   statsforecast
     #   transformers
-transformers==4.57.6 \
-    --hash=sha256:9ddc011d48c805b48c2ed52508beabbf385f3094677cbf0cd495b67162f42bf0
+transformers==5.12.1 \
+    --hash=sha256:42b75f6a0411b89c701bb9fcc447f39ce0636f063cc31acd0a432fdcd71614c6
     # via
     #   autogluon-timeseries
     #   chronos-forecasting
@@ -1008,19 +1062,24 @@ truststore==0.10.4 \
     # via
     #   httpcore2
     #   httpx2
-typer==0.26.7 \
-    --hash=sha256:66e9137cc58a77693e4d3cbb400f778e1fd59efc6b0b05eda862156d96c9e45d
+typer==0.25.1 \
+    --hash=sha256:fd5aa39cf1c0e1a8af8ebe0843ae011ae7da0f500fec2e10e4b0ae31facae726
     # via
+    #   huggingface-hub
     #   spacy
+    #   transformers
     #   weasel
-typing-extensions==4.15.0 \
-    --hash=sha256:d4c36b823c1249a191f9eb39ce8f15787da425fdf7a0029315c99a9e5338260a
+typing-extensions==4.16.0 \
+    --hash=sha256:78810d1eaf917205639551515696b3d972fa471eda49bc837bc44acfb648345e
     # via
+    #   aiohttp
     #   aiosignal
     #   alembic
     #   anyio
     #   azure-core
     #   azure-identity
+    #   azure-storage-blob
+    #   azure-storage-file-share
     #   beautifulsoup4
     #   dulwich
     #   fastapi
@@ -1046,8 +1105,8 @@ typing-inspection==0.4.2 \
 tzdata==2026.2 \
     --hash=sha256:97cd135246a60d3b1c3b8c77ff13dd509daf21b82b151cf920576378a7d72132
     # via pandas
-urllib3==2.6.3 \
-    --hash=sha256:2dd8d19eed16510c15aa5c72eeded9a1342d4506be47529859713bb5dd8bb6ac
+urllib3==2.7.0 \
+    --hash=sha256:8c0d942cee38135eb54435268fa34bceed0d0a7dff31d8aaee06c06ef8637942
     # via
     #   botocore
     #   dulwich

--- a/python/autogluonserver/pyproject.toml
+++ b/python/autogluonserver/pyproject.toml
@@ -32,8 +32,8 @@ kserve = { path = "../kserve", editable = false }
 kserve-storage = { path = "../storage", editable = false }
 
 [build-system]
-requires = ["hatchling"]
-build-backend = "hatchling.build"
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/python/autogluonserver/pyproject.toml
+++ b/python/autogluonserver/pyproject.toml
@@ -4,12 +4,12 @@ authors = [
     {name = "Dorota Laczak", email = "dlaczak@redhat.com"}
 ]
 license = {text = "Apache-2.0"}
-requires-python = "<3.13,>=3.10"
+requires-python = "<3.13,>=3.11"
 dependencies = [
     "kserve",
     "kserve-storage",
-    "autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.3",
-    "autogluon.timeseries==1.5.0+rhaiv.3",
+    "autogluon.tabular[lightgbm,xgboost,tabm,fastai]==1.5.0+rhaiv.4",
+    "autogluon.timeseries==1.5.0+rhaiv.4",
 ]
 name = "autogluonserver"
 version = "0.1.0"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: `/rerun-failed` reruns only failed jobs, `/rerun-all` reruns all jobs, `/rerun-workflow <name>` reruns a specific workflow.
-->

**What this PR does / why we need it**:

The PR fixes the hermetic build issues (https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/pipelineruns/odh-kserve-autogluon-server-v3-5-on-push-ghvz8) for kserve-autogluon-server. 

 This PR upgrades the AutoGluon server framework from 1.5.0+rhaiv.3 to 1.5.0+rhaiv.4, including:

  1. AutoGluon version update: Updates autogluon.tabular and autogluon.timeseries to 1.5.0+rhaiv.4
  2. Python version constraint adjustment: Raises minimum Python from 3.10 to 3.11 to satisfy networkx 3.6.1 dependency requirements
  3. Build backend fix: Switches from hatchling to setuptools build backend to support hermetic builds with --no-build-isolation
  4. Dependency updates: Refreshes all transitive dependencies in autogluon-all-requirements.txt (202 additions, 143 deletions)

   ## Root Cause & Technical Details

   ### networkx Dependency Conflict

  The original configuration had requires-python = ">=3.10, <3.13" but networkx==3.6.1 (required by autogluon-tabular) only supports Python >=3.11. This caused uv lock resolution failures:
  Because the requested Python version (>=3.10, <3.13) does not satisfy Python>=3.11
  and networkx==3.6.1 depends on Python>=3.11,<3.14.1

  Fix: Updated requires-python to ">=3.11, <3.13"

  ### Build Backend Incompatibility

  The autogluonserver/pyproject.toml declared hatchling as the build backend, but:
  - The Dockerfile uses --no-build-isolation at build time
  - hatchling and its dependencies (pathspec, pluggy, trove-classifiers, editables) were not included in autogluon-all-requirements.txt
  - This caused BackendUnavailable errors during pip install

  Fix: Switched to setuptools>=61.0 which is already present in the requirements file (aligns with kserve and storage packages)



**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
