### PR TITLE
feat(ci): add workflow to auto-merge manifest sync PRs from odh-model-controller

### DIFF
--- a/.github/workflows/auto-merge-manifests-sync.yml
+++ b/.github/workflows/auto-merge-manifests-sync.yml
@@ -1,0 +1,52 @@
+name: Auto-merge Manifest Sync PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'kserve-module/prefetched-manifests-rhoai/modelcontroller/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: write
+  statuses: write
+
+jobs:
+  auto-merge:
+    name: Validate and merge manifest sync PR
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'manifests-sync/odh-model-controller-')
+    steps:
+      - name: Validate changed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          CHANGED_FILES=$(gh api \
+            "repos/${REPO}/pulls/${PR_NUMBER}/files" \
+            --paginate \
+            --jq '.[].filename')
+
+          UNEXPECTED=0
+          while IFS= read -r file; do
+            if [[ "$file" != kserve-module/prefetched-manifests-rhoai/modelcontroller/* ]]; then
+              echo "ERROR: Unexpected file changed outside expected path: $file"
+              UNEXPECTED=1
+            fi
+          done <<< "$CHANGED_FILES"
+
+          if [ "$UNEXPECTED" -ne 0 ]; then
+            echo "Aborting auto-merge: PR contains changes outside kserve-module/prefetched-manifests-rhoai/modelcontroller/"
+            exit 1
+          fi
+
+          echo "All changed files are within the expected path. Proceeding with merge."
+
+      - name: Merge PR
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/auto-merge-manifests-sync.yml
+++ b/.github/workflows/auto-merge-manifests-sync.yml
@@ -29,6 +29,10 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          echo "Head ref:       $HEAD_REF"
+          echo "Repository:     $REPO"
+          echo "PR number:      $PR_NUMBER"
+
           if [[ "$HEAD_REF" == manifests-sync/odh-model-controller-* ]]; then
             ALLOWED_PREFIX="kserve-module/prefetched-manifests-rhoai/modelcontroller/"
           elif [[ "$HEAD_REF" == manifests-sync/wva-* ]]; then
@@ -37,6 +41,8 @@ jobs:
             echo "ERROR: Unrecognized sync branch pattern: $HEAD_REF"
             exit 1
           fi
+
+          echo "Allowed prefix: $ALLOWED_PREFIX"
 
           CHANGED_FILES=$(gh api \
             "repos/${REPO}/pulls/${PR_NUMBER}/files" \

--- a/.github/workflows/auto-merge-manifests-sync.yml
+++ b/.github/workflows/auto-merge-manifests-sync.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Merge PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh pr merge --merge --admin ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --merge --admin --repo "${{ github.repository }}" "${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto-merge-manifests-sync.yml
+++ b/.github/workflows/auto-merge-manifests-sync.yml
@@ -67,4 +67,4 @@ jobs:
       - name: Merge PR
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: gh pr merge --merge --admin --repo "${{ github.repository }}" "${{ github.event.pull_request.number }}"
+        run: gh pr merge --merge --admin --delete-branch --repo "${{ github.repository }}" "${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto-merge-manifests-sync.yml
+++ b/.github/workflows/auto-merge-manifests-sync.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'kserve-module/prefetched-manifests-rhoai/modelcontroller/**'
+      - 'kserve-module/prefetched-manifests-rhoai/wva/**'
 
 permissions:
   contents: write
@@ -18,14 +19,25 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.user.login == 'github-actions[bot]' &&
-      startsWith(github.event.pull_request.head.ref, 'manifests-sync/odh-model-controller-')
+      (startsWith(github.event.pull_request.head.ref, 'manifests-sync/odh-model-controller-') ||
+       startsWith(github.event.pull_request.head.ref, 'manifests-sync/wva-'))
     steps:
       - name: Validate changed files
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
+          if [[ "$HEAD_REF" == manifests-sync/odh-model-controller-* ]]; then
+            ALLOWED_PREFIX="kserve-module/prefetched-manifests-rhoai/modelcontroller/"
+          elif [[ "$HEAD_REF" == manifests-sync/wva-* ]]; then
+            ALLOWED_PREFIX="kserve-module/prefetched-manifests-rhoai/wva/"
+          else
+            echo "ERROR: Unrecognized sync branch pattern: $HEAD_REF"
+            exit 1
+          fi
+
           CHANGED_FILES=$(gh api \
             "repos/${REPO}/pulls/${PR_NUMBER}/files" \
             --paginate \
@@ -33,18 +45,18 @@ jobs:
 
           UNEXPECTED=0
           while IFS= read -r file; do
-            if [[ "$file" != kserve-module/prefetched-manifests-rhoai/modelcontroller/* ]]; then
+            if [[ "$file" != "${ALLOWED_PREFIX}"* ]]; then
               echo "ERROR: Unexpected file changed outside expected path: $file"
               UNEXPECTED=1
             fi
           done <<< "$CHANGED_FILES"
 
           if [ "$UNEXPECTED" -ne 0 ]; then
-            echo "Aborting auto-merge: PR contains changes outside kserve-module/prefetched-manifests-rhoai/modelcontroller/"
+            echo "Aborting auto-merge: PR contains changes outside ${ALLOWED_PREFIX}"
             exit 1
           fi
 
-          echo "All changed files are within the expected path. Proceeding with merge."
+          echo "All changed files are within ${ALLOWED_PREFIX}. Proceeding with merge."
 
       - name: Merge PR
         env:


### PR DESCRIPTION
**What this PR does / why we need it**:

Automates the merging of pull requests created by the `odh-model-controller`
manifest sync workflow. The workflow validates that the PR originates from
the expected bot, follows the expected branch naming convention, and only
modifies files under `kserve-module/prefetched-manifests-rhoai/`
before merging.

Related to https://redhat.atlassian.net/browse/RHOAIENG-68272

**Feature/Issue validation/testing**:

Manual testing with `act`.

