### PR TITLE
fix(autogluon): use standard Python venv instead of uv venv

### DIFF
--- a/Dockerfiles/autogluon.Dockerfile.konflux
+++ b/Dockerfiles/autogluon.Dockerfile.konflux
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="registry.redhat.io/rhai/base-image-cpu-rhel9@sha256:118425714f88c5b24cd67e828e0bcc7a9bc634ab2a1448e8f0975dfd85aea45c"
+ARG BASE_IMAGE="quay.io/aipcc/base-images/cpu:3.5"
 
 FROM ${BASE_IMAGE} AS builder
 
@@ -10,7 +10,7 @@ USER root
 # Create virtual environment
 ENV VIRTUAL_ENV=/opt/app-root/.venv
 ENV PATH="${VIRTUAL_ENV}/bin:$PATH"
-RUN uv venv -p 3.12 ${VIRTUAL_ENV}
+RUN python3.12 -m venv ${VIRTUAL_ENV}
 
 # ========== Copy all dependencies ==========
 COPY kserve/pyproject.toml kserve/


### PR DESCRIPTION
Switch from 'uv venv' to 'python3.12 -m venv' to fix ModuleNotFoundError when running pip-licenses.py. Using standard venv ensures pip and python are fully compatible and packages can be found at runtime.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kserve/kserve/blob/master/docs/DEVELOPER_GUIDE.md
2. Before raising a PR, please run `make precommit` to check the code style.
3. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
4. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
6. Re-running failed tests: `/rerun-failed` reruns only failed jobs, `/rerun-all` reruns all jobs, `/rerun-workflow <name>` reruns a specific workflow.
-->

**What this PR does / why we need it**:
Switch from 'uv venv' to 'python3.12 -m venv' to fix ModuleNotFoundError when running pip-licenses.py. Using standard venv ensures pip and python are fully compatible and packages can be found at runtime.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # autogluon build https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/rhoai-v3-5/pipelineruns/odh-kserve-autogluon-server-v3-5-on-push-x2hms/logs

https://redhat.atlassian.net/browse/RHOAIENG-71424

**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Tested the build in konflux: https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/rhoai-tenant/applications/automation/pipelineruns/odh-kserve-autogluon-server-on-pull-request-mm8sf 


- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
