### PR TITLE
fix(ocp/rbac): unset llminferenceservice SCC priority

### DIFF
--- a/config/overlays/odh/llm-svc-scc.yaml
+++ b/config/overlays/odh/llm-svc-scc.yaml
@@ -2,7 +2,14 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: openshift-ai-llminferenceservice-scc
-priority: 10
+# priority is intentionally null. OCP SCC admission evaluates the union of the
+# pod's ServiceAccount and the identity that submits the pod create, then selects
+# the highest-priority SCC available to either. A positive priority makes this SCC
+# auto-win over restricted-v2 for any pod created by a broadly-privileged requestor
+# (e.g. a GitOps controller), hijacking unrelated workloads. With null priority
+# this SCC is only selected when a pod actually requires the extra capabilities it
+# grants; otherwise OCP falls back to a more restrictive SCC.
+priority: null
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
@@ -46,7 +53,15 @@ kind: SecurityContextConstraints
 apiVersion: security.openshift.io/v1
 metadata:
   name: openshift-ai-llminferenceservice-multi-node-scc
-priority: 11
+# priority is intentionally null. OCP SCC admission evaluates the union of the
+# pod's ServiceAccount and the identity that submits the pod create, then selects
+# the highest-priority SCC available to either. A positive priority makes this SCC
+# auto-win over restricted-v2 for any pod created by a broadly-privileged requestor
+# (e.g. a GitOps controller), hijacking unrelated workloads. With null priority
+# this SCC is only selected when a pod actually requires the extra capabilities it
+# grants (e.g. hostPath for multi-node); otherwise OCP falls back to a more
+# restrictive SCC.
+priority: null
 allowHostDirVolumePlugin: true
 allowHostIPC: false
 allowHostNetwork: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of opendatahub-io/kserve#1662 to `rhoai-2.25`.

Unsets the `priority` field on both LLMInferenceService SCCs in `config/overlays/odh/llm-svc-scc.yaml`:
- `openshift-ai-llminferenceservice-scc` (was `priority: 10`)
- `openshift-ai-llminferenceservice-multi-node-scc` (was `priority: 11`)

OCP SCC admission evaluates the union of the pod's ServiceAccount and the identity that submits the pod create, then selects the highest-priority SCC available to either. With a positive priority, these SCCs auto-win over `restricted-v2` for any pod created by a broadly-privileged requestor (e.g. a GitOps controller running with cluster-admin-equivalent RBAC), so unrelated workloads get assigned the RHOAI SCC. Unsetting the priority means these SCCs are only selected when a pod actually requires the capabilities they grant.

**Which issue(s) this PR fixes**:
Fixes #

(Jira: [RHOAIENG-54150](https://redhat.atlassian.net/browse/RHOAIENG-54150))

**Feature/Issue validation/testing**:

Verified on a ROSA cluster with a live RHOAI 2.25-equivalent install, using the exact 2.25 manifest:

- [x] With priorities 10/11, an unrelated pod created by a broadly-privileged requestor was assigned `openshift-ai-llminferenceservice-multi-node-scc`; after nulling both, our SCCs are no longer selected.
- [x] No regression: a pod that declares `IPC_LOCK` still selects `openshift-ai-llminferenceservice-scc` at null priority, since `restricted-v2` cannot admit added capabilities.

**Special notes for your reviewer**:

No image version changes. Backport of the merged midstream fix opendatahub-io/kserve#1662. Hardening; note that fully achieving `restricted-v2` for unrelated GitOps-submitted workloads also requires scoping down the submitting controllers' RBAC (customer-side).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works? (Validated on-cluster; SCC priority is a static manifest value not covered by unit tests.)
- [x] Has code been commented, particularly in hard-to-understand areas? (Comment added in the manifest explaining why priority is unset.)
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:

```release-note
Unset the priority on the LLMInferenceService SCCs so they are no longer auto-selected over restricted-v2 for unrelated workloads created by broadly-privileged requestors.
```