### PR TITLE
[RHOAIENG-74808] CVE-2025-66471: pin urllib3 >=2.7.0 for storage

### DIFF
--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -59,6 +59,7 @@ pandas =  "^2.2.0"
 pydantic = "^2.5.0"
 pyyaml = "^6.0.0"
 # CVE-2025-66418 urllib3: Unbounded decompression chain leads to resource exhaustion
+# CVE-2025-66471 urllib3: Streaming API improperly handles highly compressed data
 # CVE-2026-44432 urllib3: Denial of Service due to excessive HTTP response decompression
 urllib3 = ">=2.7.0,<3.0.0"
 # CVE-2025-69223 AIOHTTP's HTTP Parser auto_decompress feature is vulnerable to zip bomb

--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -1051,22 +1051,22 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.3.0"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 files = [
-    {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
-    {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
-brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+brotli = ["brotli (>=1.2.0)", "brotlicffi (>=1.2.0.0)"]
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
-zstd = ["zstandard (>=0.18.0)"]
+zstd = ["backports-zstd (>=1.0.0)"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "9d645f1003055f9984096897c00ea8e7822be7bd189e4d9e88e7d3e8ba482ca3"
+content-hash = "106b0cd132bc1b79f8723cea423381e710628429370e4939999cbd27782c9f8d"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -28,6 +28,9 @@ azure-storage-file-share = { version = "^12.16.0"}
 azure-identity = { version = "^1.15.0"}
 boto3 = { version = "^1.29.0"}
 huggingface-hub = { version = "^0.30.0", extras = ["hf-transfer"]}
+# CVE-2025-66471 urllib3: Streaming API improperly handles highly compressed data
+# Pinning because it is a transitive dependency via requests.
+urllib3 = {version = ">=2.7.0,<3.0.0"}
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
 # CVE-2026-48526 PyJWT authentication bypass via JWK accepted as HMAC secret
 # Pinning because it is a transitive dependency.


### PR DESCRIPTION
## Summary

- Pin `urllib3 >=2.7.0,<3.0.0` in `python/storage/pyproject.toml` to fix CVE-2025-66471 (Streaming API DoS via highly compressed data)
- Regenerate `python/storage/poetry.lock` (2.3.0 → 2.7.0)
- Add CVE-2025-66471 comment on existing kserve urllib3 constraint

## JIRA

https://issues.redhat.com/browse/RHOAIENG-74808

## Test plan

- [ ] Konflux CI builds storage-initializer image successfully
- [ ] `poetry lock --check` passes for `python/storage`