### PR TITLE
Cherrypick - fix(kserve-module): read cert-manager params from platform ConfigMap

### DIFF
--- a/kserve-module/pkg/kservemodule/certmanager.go
+++ b/kserve-module/pkg/kservemodule/certmanager.go
@@ -1,0 +1,13 @@
+package kservemodule
+
+func buildCertManagerParams(namespace string, configData map[string]string, certManagerNS string) map[string]string {
+	return map[string]string{
+		"NAMESPACE":                 namespace,
+		"ISSUER_REF_NAME":           configOrDefault(configData, certManagerIssuerRefNameKey, defaultCAIssuerName),
+		"ISSUER_REF_KIND":           configOrDefault(configData, certManagerIssuerRefKindKey, defaultIssuerRefKind),
+		"ISSUER_REF_GROUP":          "cert-manager.io",
+		"CA_SECRET_NAME":            configOrDefault(configData, certManagerCASecretNameKey, defaultCertName),
+		"CA_SECRET_NAMESPACE":       configOrDefault(configData, certManagerCASecretNamespaceKey, certManagerNS),
+		"ISTIO_CA_CERTIFICATE_PATH": configOrDefault(configData, certManagerIstioCACertPathKey, defaultIstioCACertPath),
+	}
+}

--- a/kserve-module/pkg/kservemodule/constants.go
+++ b/kserve-module/pkg/kservemodule/constants.go
@@ -73,12 +73,19 @@ const (
 	defaultIssuerRefKind = "ClusterIssuer"
 	defaultCertName      = "opendatahub-ca"
 	// defaultCertManagerNS is the fallback when dynamic detection fails.
-	// Prefer CA_SECRET_NAMESPACE env var or runtime discovery.
+	// Prefer platform ConfigMap or runtime discovery.
 	defaultCertManagerNS   = "cert-manager"
 	defaultIstioCACertPath = "/var/run/secrets/opendatahub/ca.crt"
 
 	// Well-known cert-manager namespace candidates for discovery.
-	certManagerNSCandidate        = "cert-manager"
-	certManagerOperatorNS         = "cert-manager-operator"
-	certManagerWebhookDeployment  = "cert-manager-webhook"
+	certManagerNSCandidate       = "cert-manager"
+	certManagerOperatorNS        = "cert-manager-operator"
+	certManagerWebhookDeployment = "cert-manager-webhook"
+
+	// Platform ConfigMap keys for cert-manager config (injected by ODH operator on XKS).
+	certManagerIssuerRefNameKey     = "CERT_MANAGER_ISSUER_REF_NAME"
+	certManagerIssuerRefKindKey     = "CERT_MANAGER_ISSUER_REF_KIND"
+	certManagerCASecretNameKey      = "CERT_MANAGER_CA_SECRET_NAME"
+	certManagerCASecretNamespaceKey = "CERT_MANAGER_CA_SECRET_NAMESPACE"
+	certManagerIstioCACertPathKey   = "CERT_MANAGER_ISTIO_CA_CERT_PATH"
 )

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -1,6 +1,5 @@
 package kservemodule
 
-import "os"
 
 var kserveImageParamMap = map[string]string{
 	"kserve-controller":                                "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
@@ -90,23 +89,4 @@ var modelControllerImageParamMap = map[string]string{
 
 var wvaImageParamMap = map[string]string{
 	"wva-controller-image": "RELATED_IMAGE_ODH_WORKLOAD_VARIANT_AUTOSCALER_CONTROLLER_IMAGE",
-}
-
-func buildCertManagerParams(namespace, certManagerNS string) map[string]string {
-	return map[string]string{
-		"NAMESPACE":                 namespace,
-		"ISSUER_REF_NAME":           getEnvOrDefault("ISSUER_NAME", defaultCAIssuerName),
-		"ISSUER_REF_KIND":           getEnvOrDefault("ISSUER_KIND", defaultIssuerRefKind),
-		"ISSUER_REF_GROUP":          "cert-manager.io",
-		"CA_SECRET_NAME":            getEnvOrDefault("CA_SECRET_NAME", defaultCertName),
-		"CA_SECRET_NAMESPACE":       getEnvOrDefault("CA_SECRET_NAMESPACE", certManagerNS),
-		"ISTIO_CA_CERTIFICATE_PATH": getEnvOrDefault("ISTIO_CA_CERT_PATH", defaultIstioCACertPath),
-	}
-}
-
-func getEnvOrDefault(key, defaultVal string) string {
-	if v := os.Getenv(key); v != "" {
-		return v
-	}
-	return defaultVal
 }

--- a/kserve-module/pkg/kservemodule/params_test.go
+++ b/kserve-module/pkg/kservemodule/params_test.go
@@ -112,7 +112,7 @@ func TestApplyParams_ExtraParamsMap(t *testing.T) {
 func TestBuildCertManagerParams_Defaults(t *testing.T) {
 	g := NewWithT(t)
 
-	params := buildCertManagerParams("test-ns", defaultCertManagerNS)
+	params := buildCertManagerParams("test-ns", nil, defaultCertManagerNS)
 	g.Expect(params["NAMESPACE"]).Should(Equal("test-ns"))
 	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal(defaultCAIssuerName))
 	g.Expect(params["ISSUER_REF_KIND"]).Should(Equal(defaultIssuerRefKind))
@@ -122,20 +122,41 @@ func TestBuildCertManagerParams_Defaults(t *testing.T) {
 	g.Expect(params["ISTIO_CA_CERTIFICATE_PATH"]).Should(Equal(defaultIstioCACertPath))
 }
 
-func TestBuildCertManagerParams_EnvOverrides(t *testing.T) {
-	g := NewWithT(t)
-
-	t.Setenv("ISSUER_NAME", "custom-issuer")
-	t.Setenv("CA_SECRET_NAME", "custom-ca")
-
-	params := buildCertManagerParams("ns", "custom-ns")
-	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal("custom-issuer"))
-	g.Expect(params["CA_SECRET_NAME"]).Should(Equal("custom-ca"))
-}
-
 func TestBuildCertManagerParams_DynamicNamespace(t *testing.T) {
 	g := NewWithT(t)
 
-	params := buildCertManagerParams("test-ns", "cert-manager-operator")
+	params := buildCertManagerParams("test-ns", nil, "cert-manager-operator")
 	g.Expect(params["CA_SECRET_NAMESPACE"]).Should(Equal("cert-manager-operator"))
+}
+
+func TestBuildCertManagerParams_ConfigMapValues(t *testing.T) {
+	g := NewWithT(t)
+
+	configData := map[string]string{
+		certManagerIssuerRefNameKey:   "rhai-ca-issuer",
+		certManagerIssuerRefKindKey:   "Issuer",
+		certManagerCASecretNameKey:    "rhai-ca",
+		certManagerIstioCACertPathKey: "/var/run/secrets/rhai/ca.crt",
+	}
+
+	params := buildCertManagerParams("test-ns", configData, defaultCertManagerNS)
+	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal("rhai-ca-issuer"))
+	g.Expect(params["ISSUER_REF_KIND"]).Should(Equal("Issuer"))
+	g.Expect(params["CA_SECRET_NAME"]).Should(Equal("rhai-ca"))
+	g.Expect(params["ISTIO_CA_CERTIFICATE_PATH"]).Should(Equal("/var/run/secrets/rhai/ca.crt"))
+	g.Expect(params["NAMESPACE"]).Should(Equal("test-ns"))
+	g.Expect(params["ISSUER_REF_GROUP"]).Should(Equal("cert-manager.io"))
+}
+
+func TestBuildCertManagerParams_PartialConfigMap(t *testing.T) {
+	g := NewWithT(t)
+
+	configData := map[string]string{
+		certManagerIssuerRefNameKey: "rhai-ca-issuer",
+	}
+
+	params := buildCertManagerParams("ns", configData, defaultCertManagerNS)
+	g.Expect(params["ISSUER_REF_NAME"]).Should(Equal("rhai-ca-issuer"))
+	g.Expect(params["ISSUER_REF_KIND"]).Should(Equal(defaultIssuerRefKind))
+	g.Expect(params["CA_SECRET_NAME"]).Should(Equal(defaultCertName))
 }

--- a/kserve-module/pkg/kservemodule/reconciler.go
+++ b/kserve-module/pkg/kservemodule/reconciler.go
@@ -317,10 +317,11 @@ func (r *KserveModuleReconciler) reconcileComponent(ctx context.Context,
 
 	if r.isKubernetes(ctx) {
 		ns := r.getApplicationsNamespace()
-		certNS := r.getCertManagerNamespace(ctx)
+		configData := r.getPlatformConfigData(ctx)
+		certNS := r.getCertManagerNamespace(ctx, configData)
 		if err := applyParams(
 			filepath.Join(manifestDir, comp.dirName(), comp.sourcePathXKS),
-			nil, buildCertManagerParams(ns, certNS),
+			nil, buildCertManagerParams(ns, configData, certNS),
 		); err != nil {
 			return nil, fmt.Errorf("applying cert-manager params: %w", err)
 		}
@@ -399,12 +400,12 @@ func (r *KserveModuleReconciler) getApplicationsNamespace() string {
 
 // getCertManagerNamespace dynamically discovers the namespace where cert-manager
 // stores its CA secrets. It checks (in order):
-// 1. CA_SECRET_NAMESPACE env var (explicit override)
+// 1. Platform ConfigMap (CERT_MANAGER_CA_SECRET_NAMESPACE key)
 // 2. "cert-manager" namespace existence on the cluster
 // 3. "cert-manager-operator" namespace existence (OCP OLM install)
 // 4. Falls back to "cert-manager" constant
-func (r *KserveModuleReconciler) getCertManagerNamespace(ctx context.Context) string {
-	if ns := os.Getenv("CA_SECRET_NAMESPACE"); ns != "" {
+func (r *KserveModuleReconciler) getCertManagerNamespace(ctx context.Context, configData map[string]string) string {
+	if ns, ok := configData[certManagerCASecretNamespaceKey]; ok && ns != "" {
 		return ns
 	}
 
@@ -419,15 +420,19 @@ func (r *KserveModuleReconciler) getCertManagerNamespace(ctx context.Context) st
 	return defaultCertManagerNS
 }
 
-func (r *KserveModuleReconciler) getPlatformVersion(ctx context.Context) string {
+func (r *KserveModuleReconciler) getPlatformConfigData(ctx context.Context) map[string]string {
 	cm := &corev1.ConfigMap{}
 	key := types.NamespacedName{Name: platformVersionConfigMap, Namespace: r.getApplicationsNamespace()}
 	if err := r.Get(ctx, key, cm); err != nil {
-		ctrl.LoggerFrom(ctx).V(1).Info("ConfigMap not found, platform version unknown",
+		ctrl.LoggerFrom(ctx).V(1).Info("Platform ConfigMap not found",
 			"configmap", key, "error", err)
-		return ""
+		return nil
 	}
-	return cm.Data[platformVersionConfigMapKey]
+	return cm.Data
+}
+
+func (r *KserveModuleReconciler) getPlatformVersion(ctx context.Context) string {
+	return configOrDefault(r.getPlatformConfigData(ctx), platformVersionConfigMapKey, "")
 }
 
 func (r *KserveModuleReconciler) getVersionPrefix(ctx context.Context, kserve *platformv1alpha1.Kserve) string {

--- a/kserve-module/pkg/kservemodule/util.go
+++ b/kserve-module/pkg/kservemodule/util.go
@@ -1,0 +1,8 @@
+package kservemodule
+
+func configOrDefault(configData map[string]string, key, defaultVal string) string {
+	if v, ok := configData[key]; ok && v != "" {
+		return v
+	}
+	return defaultVal
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherrypick - https://github.com/opendatahub-io/kserve/pull/1824

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:

<!--Please describe the tests that you ran to verify your changes and relevant result summary. Provide instructions so it can be reproduced.
Please also list any relevant details for your test configuration. -->

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

<!-- 1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes. -->

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [ ] Have you linked the JIRA issue(s) to this PR?

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
