### PR TITLE
cherry-pick: fix(llmisvc): add NetworkPolicy for llmisvc-controller-manager (RHOAIENG-79306)

### DIFF
--- a/config/overlays/odh/network-policies.yaml
+++ b/config/overlays/odh/network-policies.yaml
@@ -9,3 +9,14 @@ spec:
       control-plane: kserve-controller-manager
   ingress:
     - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: llmisvc-controller-manager
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: llmisvc-controller-manager
+  ingress:
+    - {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of https://github.com/opendatahub-io/kserve/pull/1823 onto `rhoai-3.5`.

On ROKS, the `redhat-ods-applications` namespace has a default-deny NetworkPolicy. `kserve-controller-manager` already has an allow-all ingress NetworkPolicy, but `llmisvc-controller-manager` did not, so webhook calls from the API server failed and `LLMInferenceServiceConfig` creation failed during RHOAI 3.5 install.

This adds the matching NetworkPolicy for `llmisvc-controller-manager`.

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-79306](https://redhat.atlassian.net/browse/RHOAIENG-79306)

**Feature/Issue validation/testing**:
- [x] Diff matches ODH PR #1823 (adds NetworkPolicy for `llmisvc-controller-manager`)
- [ ] CI green on this PR

**Special notes for your reviewer**:
Manual cherry-pick because `rhoai-3.5` auto-sync is frozen.
Upstream: https://github.com/opendatahub-io/kserve/pull/1823
Cherry-picked from commit 1995336861faec38ccf602c5a869077e61ded9fc

**Checklist**:
- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
Fix LLMInferenceServiceConfig creation failure on ROKS by adding an allow-all ingress NetworkPolicy for llmisvc-controller-manager.