### PR TITLE
Fix disconnected readiness blockers for RHOAI 3.6-ea.1

### DIFF
--- a/kserve-module/config/kustomization.yaml
+++ b/kserve-module/config/kustomization.yaml
@@ -10,5 +10,3 @@ resources:
 
 images:
 - name: kserve-module-controller
-  newName: quay.io/opendatahub/odh-kserve-module-operator
-  newTag: odh-stable

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -39,7 +39,7 @@ var kserveImageParamMap = map[string]string{
 	"kserve-localmodel-controller":                     "RELATED_IMAGE_ODH_KSERVE_LOCALMODEL_CONTROLLER_IMAGE",
 	"kserve-localmodelnode-agent":                      "RELATED_IMAGE_ODH_KSERVE_LOCALMODELNODE_AGENT_IMAGE",
 	"kserve-llm-d-latency-predictor-prediction":        "RELATED_IMAGE_ODH_LATENCY_PREDICTOR_PREDICTION_IMAGE",
-	"kserve-llm-d-latency-predictor-training":          "RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE",
+	"kserve-llm-d-latency-predictor-training":          "RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE",
 	"ovms-versioning-ubi-micro":                        "RELATED_IMAGE_ODH_UBI_MICRO_IMAGE",
 }
 

--- a/kserve-module/tests/scripts/setup-cluster.sh
+++ b/kserve-module/tests/scripts/setup-cluster.sh
@@ -342,7 +342,7 @@ deploy_kserve_module() {
 
   if [[ -n "${KSERVE_MODULE_IMG}" ]]; then
     log_info "Using custom image: ${KSERVE_MODULE_IMG}"
-    output=$(echo "$output" | sed "s|image: .*odh-kserve-module-operator.*|image: ${KSERVE_MODULE_IMG}|g")
+    output=$(echo "$output" | sed "s|image: kserve-module-controller|image: ${KSERVE_MODULE_IMG}|g")
   fi
 
   echo "$output" | ${KUBECTL} apply --server-side=true --force-conflicts -f -


### PR DESCRIPTION
## Summary
Fix three disconnected readiness blockers for RHOAI 3.6-ea.1:
1. Latency predictor training image env var name
2. Hardcoded kserve-module-operator image reference
3. E2E test image injection

## Changes

### 1. Fix latency predictor training image env var name
**File**: `kserve-module/pkg/kservemodule/images.go`
- Change `RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TEST_IMAGE` to `RELATED_IMAGE_ODH_LATENCY_PREDICTOR_TRAINING_IMAGE`
- Aligns with naming convention and build configs

### 2. Remove hardcoded kserve-module-operator image
**File**: `kserve-module/config/kustomization.yaml`
- Remove `newName` and `newTag` from kustomization
- Allows ODH operator to inject image reference from params.env via `RELATED_IMAGE_ODH_KSERVE_MODULE_OPERATOR_IMAGE`

### 3. Fix e2e test image injection
**File**: `kserve-module/tests/scripts/setup-cluster.sh`
- Update sed pattern from `image: .*odh-kserve-module-operator.*` to `image: kserve-module-controller`
- Matches new placeholder-only image reference after removing hardcoded values

## Related PRs
- ODH upstream: https://github.com/opendatahub-io/kserve/pull/1833
- RHOAI-Build-Config 3.6-ea.1: https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/28174
- RHOAI-Build-Config 3.5: https://github.com/red-hat-data-services/RHOAI-Build-Config/pull/28163

🤖 Generated with [Claude Code](https://claude.com/claude-code)