### PR TITLE
fix(modelcache): relabel local model cache to a shared SELinux level

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -203,7 +203,7 @@ require (
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.42.0 // indirect
+	golang.org/x/sys v0.42.0
 	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/controller/v1alpha1/localmodelnode/controller.go
+++ b/pkg/controller/v1alpha1/localmodelnode/controller.go
@@ -569,7 +569,7 @@ func (c *LocalModelNodeReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		fsHelper = NewFileSystemHelper(modelsRootFolder)
 	}
 
-	folderResult, err := c.ensureModelRootFolderExistsAndIsWritable(ctx, localModelConfig)
+	folderResult, err := c.ensureModelRootFolderExistsAndIsWritable(ctx)
 	if err != nil || !folderResult.Continue {
 		if folderResult != nil {
 			return folderResult.Result, err

--- a/pkg/controller/v1alpha1/localmodelnode/file_utils_odh.go
+++ b/pkg/controller/v1alpha1/localmodelnode/file_utils_odh.go
@@ -18,7 +18,15 @@ limitations under the License.
 
 package localmodelnode
 
-import "os"
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
 
 // isModelRootWritable checks if the model root folder is writable.
 // Defined as a var for test overriding.
@@ -31,4 +39,73 @@ var isModelRootWritable = func() bool {
 	_ = file.Close()
 	_ = os.Remove(name)
 	return true
+}
+
+// mcsLevelIsCategorized reports whether an SELinux MCS level carries categories. The level is
+// "<sensitivity>[:categories]"; categories, when present, follow a colon (e.g. "s0:c2,c28"),
+// while a bare "s0" or an "s0-s0" range carries none.
+func mcsLevelIsCategorized(level string) bool {
+	return strings.Contains(level, ":")
+}
+
+// selinuxMCSLevel reads the MCS level of path from its security.selinux xattr. ok is false when
+// the node/filesystem carries no SELinux label (ENODATA / ENOTSUP) so callers do not treat a
+// non-SELinux node as needing a relabel.
+func selinuxMCSLevel(path string) (level string, ok bool, err error) {
+	// Query the required size first (dest == nil returns the length) — a context with many
+	// explicitly-listed categories can exceed a small fixed buffer and would otherwise return
+	// ERANGE, which is not ENODATA/ENOTSUP and would be misread as an unexpected error.
+	size, err := unix.Lgetxattr(path, "security.selinux", nil)
+	if err != nil {
+		if errors.Is(err, unix.ENODATA) || errors.Is(err, unix.ENOTSUP) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	buf := make([]byte, size)
+	n, err := unix.Lgetxattr(path, "security.selinux", buf)
+	if err != nil {
+		if errors.Is(err, unix.ENODATA) || errors.Is(err, unix.ENOTSUP) {
+			return "", false, nil
+		}
+		return "", false, err
+	}
+	return parseMCSLevel(string(buf[:n])), true, nil
+}
+
+// folderHasNonSharedMCS reports whether the model directory at path, or any descendant, carries
+// SELinux MCS *categories* (i.e. a level other than the shared, category-less floor). Anything
+// categorized is unreadable from a consuming namespace whose MCS category set does not dominate
+// it, so it must be relabeled to the shared level. Defined as a var so tests can inject behavior
+// without a real SELinux filesystem.
+//
+// The whole tree is walked, not just the directory or its immediate children, because SELinux
+// assigns a newly-created file the *creating process's* MCS level, not the parent directory's:
+// a re-download into a previously-relabeled (s0) directory writes categorized files under an s0
+// dir, and storage-initializer preserves nested object paths, so a categorized file can appear
+// arbitrarily deep. The walk exits early (filepath.SkipAll) on the first categorized entry, so
+// the common (healthy) cost is a full traversal while a problem is found on the first offender.
+//
+// Returns (false, nil) when SELinux is disabled or the filesystem does not support labels
+// (ENODATA / ENOTSUP), so non-SELinux nodes never trigger a relabel loop.
+var folderHasNonSharedMCS = func(path string) (bool, error) {
+	categorized := false
+	walkErr := filepath.WalkDir(path, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		level, ok, lvlErr := selinuxMCSLevel(p)
+		if lvlErr != nil {
+			return lvlErr
+		}
+		if ok && mcsLevelIsCategorized(level) {
+			categorized = true
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if walkErr != nil {
+		return false, walkErr
+	}
+	return categorized, nil
 }

--- a/pkg/controller/v1alpha1/localmodelnode/platform_default.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_default.go
@@ -23,8 +23,6 @@ import (
 	"fmt"
 
 	batchv1 "k8s.io/api/batch/v1"
-
-	"github.com/kserve/kserve/pkg/apis/serving/v1beta1"
 )
 
 const MountPath = "/mnt/models"
@@ -35,7 +33,6 @@ func (c *LocalModelNodeReconciler) enhanceDownloadJob(_ context.Context, _ *batc
 
 // TODO we need a way to ensure that the local path on persistent volume is the same as the local path of the node agent DaemonSet.
 func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(_ context.Context,
-	_ *v1beta1.LocalModelConfig,
 ) (*ensureModelRootFolderResult, error) {
 	if err := fsHelper.ensureModelRootFolderExists(); err != nil {
 		return nil, fmt.Errorf("failed to ensure model root folder: %w", err)

--- a/pkg/controller/v1alpha1/localmodelnode/platform_odh.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_odh.go
@@ -27,6 +27,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -45,8 +46,47 @@ import (
 
 const MountPath = "/var/lib/kserve"
 
+// sharedMCSLevel is the category-less SELinux MCS level applied to the cached model tree.
+// The cache is a shared, read-only, cross-namespace hostPath artifact: a directory can carry
+// exactly one SELinux label, and hostPath / local PVs are never relabeled per-consumer by the
+// kubelet. An empty category set is a subset of every consumer namespace's categories, so a
+// category-less level is the only label readable by all consumers simultaneously.
+const sharedMCSLevel = "s0"
+
 // Categories may be comma-separated (typical on OCP) or dot-separated (e.g. Fedora: s0-s0:c0.c1023).
 var validMCSLevel = regexp.MustCompile(`^s\d+(-s\d+)?(:c\d{1,4}([,.]c\d{1,4})*)?$`)
+
+// maxRelabelAttempts bounds how many consecutive reconciles may launch a permission-fix job for a
+// model folder that never reaches the shared MCS level. Without it, a folder whose label can never
+// be cleared — a read-only mount, a filesystem that rejects the relabel, or a persistent xattr
+// read error — would recreate a privileged relabel job every reconcile once the previous job's TTL
+// expires, an unbounded privileged-pod churn (CWE-400). The count is per model folder and resets
+// as soon as that folder reads at the shared level, so legitimate sequential downloads (each
+// relabeled successfully) never trip the cap.
+const maxRelabelAttempts = 20
+
+var (
+	relabelAttemptsMu sync.Mutex
+	relabelAttempts   = map[string]int{}
+)
+
+func recordRelabelAttempt(path string) {
+	relabelAttemptsMu.Lock()
+	defer relabelAttemptsMu.Unlock()
+	relabelAttempts[path]++
+}
+
+func relabelAttemptCount(path string) int {
+	relabelAttemptsMu.Lock()
+	defer relabelAttemptsMu.Unlock()
+	return relabelAttempts[path]
+}
+
+func resetRelabelAttempts(path string) {
+	relabelAttemptsMu.Lock()
+	defer relabelAttemptsMu.Unlock()
+	delete(relabelAttempts, path)
+}
 
 func (c *LocalModelNodeReconciler) enhanceDownloadJob(ctx context.Context, job *batchv1.Job, storageKey string) error {
 	containers := job.Spec.Template.Spec.Containers
@@ -76,7 +116,6 @@ func (c *LocalModelNodeReconciler) enhanceDownloadJob(ctx context.Context, job *
 }
 
 func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(ctx context.Context,
-	localModelConfig *v1beta1.LocalModelConfig,
 ) (*ensureModelRootFolderResult, error) {
 	needsPermFix := false
 
@@ -103,11 +142,47 @@ func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(ctx 
 					continue
 				}
 				subdir := filepath.Join(modelsRootFolder, entry.Name())
-				if _, err := os.ReadDir(subdir); err != nil && os.IsPermission(err) {
-					c.Log.Info("Subdirectory has permission issues", "path", subdir, "error", err)
+				if _, err := os.ReadDir(subdir); err != nil {
+					if os.IsPermission(err) {
+						c.Log.Info("Subdirectory has permission issues", "path", subdir, "error", err)
+						needsPermFix = true
+						break
+					}
+					// Non-permission error (e.g. the entry was removed between listing the
+					// parent and this read): log and skip rather than probing the SELinux
+					// label of a path that may no longer exist.
+					c.Log.Info("Skipping unreadable subdirectory", "path", subdir, "error", err)
+					continue
+				}
+				// A folder carrying MCS categories (i.e. not the shared level) is unreadable from
+				// a consuming namespace whose category set does not dominate it — the download job
+				// writes files at the job namespace's MCS, so the agent (same MCS) reads fine and
+				// marks NodeDownloaded, but a serving pod in another namespace is denied. Relabel
+				// to the shared level. This also self-heals caches downloaded before this fix.
+				categorized, mcsErr := folderHasNonSharedMCS(subdir)
+				if mcsErr != nil || categorized {
+					// Bound retries. A folder that can never reach the shared level (read-only
+					// mount, a filesystem that rejects the relabel, or a persistent xattr read
+					// error) must not recreate a privileged relabel job every reconcile once the
+					// prior job's TTL expires. launchPermissionFixJob's dedupe only holds while a
+					// job object exists — it does not survive the TTL GC — so it is not a loop
+					// guard on its own. After the cap, give up on this folder and surface an error.
+					if relabelAttemptCount(subdir) >= maxRelabelAttempts {
+						c.Log.Error(mcsErr, "Giving up on SELinux relabel after repeated attempts; manual intervention required",
+							"path", subdir, "attempts", maxRelabelAttempts, "categorized", categorized)
+						continue
+					}
+					recordRelabelAttempt(subdir)
+					if mcsErr != nil {
+						c.Log.Info("Could not read SELinux label, relabeling conservatively", "path", subdir, "error", mcsErr)
+					} else {
+						c.Log.Info("Subdirectory carries non-shared MCS categories, needs relabel", "path", subdir)
+					}
 					needsPermFix = true
 					break
 				}
+				// Folder is at the shared level — clear any prior failed-attempt count.
+				resetRelabelAttempts(subdir)
 			}
 		}
 		if !needsPermFix {
@@ -128,23 +203,30 @@ func (c *LocalModelNodeReconciler) ensureModelRootFolderExistsAndIsWritable(ctx 
 	if permissionFixImage == "" {
 		return nil, errors.New("modelcachePermissionFixImage not configured in inferenceservice-config")
 	}
-	mcsLevel, err := c.resolveMCSLevel(ctx, localModelConfig.JobNamespace)
-	if err != nil {
-		c.Log.Error(err, "Invalid MCS level")
-		return nil, err
-	}
-
 	// Fetch the LocalModelNode to set as owner of the permission fix job
 	lmn := &v1alpha1.LocalModelNode{}
 	if err := c.Get(ctx, types.NamespacedName{Name: nodeName}, lmn); err != nil {
 		return nil, fmt.Errorf("failed to get LocalModelNode for owner reference: %w", err)
 	}
 
-	if err := c.launchPermissionFixJob(ctx, mcsLevel, permissionFixImage, lmn); err != nil {
+	if err := c.launchPermissionFixJob(ctx, permissionFixImage, lmn); err != nil {
 		c.Log.Error(err, "Failed to launch permission fix job")
 		return nil, err
 	}
 	return &ensureModelRootFolderResult{Result: ctrl.Result{RequeueAfter: 10 * time.Second}}, nil
+}
+
+// parseMCSLevel extracts the SELinux level (sensitivity plus optional categories) from a full
+// SELinux context string, e.g. "system_u:object_r:container_file_t:s0:c2,c28" -> "s0:c2,c28".
+// It MUST use SplitN with a limit of 4: the level itself contains a colon, so a plain
+// Split(":")[3] would return only "s0", drop the categories, and silently defeat MCS handling.
+// Returns "" when the context has fewer than 4 colon-separated segments.
+func parseMCSLevel(selinuxContext string) string {
+	parts := strings.SplitN(strings.Trim(selinuxContext, "\x00 \n\r"), ":", 4)
+	if len(parts) < 4 {
+		return ""
+	}
+	return parts[3]
 }
 
 func getProcessMCSLevel() string {
@@ -152,11 +234,7 @@ func getProcessMCSLevel() string {
 	if err != nil {
 		return ""
 	}
-	parts := strings.SplitN(strings.Trim(string(data), "\x00 \n\r"), ":", 4)
-	if len(parts) < 4 {
-		return ""
-	}
-	return parts[3]
+	return parseMCSLevel(string(data))
 }
 
 func (c *LocalModelNodeReconciler) resolveMCSLevel(ctx context.Context, namespace string) (string, error) {
@@ -196,7 +274,7 @@ func (c *LocalModelNodeReconciler) resolveMCSLevelFromProcessOrDefault() (string
 	return mcsLevel, nil
 }
 
-func (c *LocalModelNodeReconciler) launchPermissionFixJob(ctx context.Context, mcsLevel string, permissionFixImage string, owner *v1alpha1.LocalModelNode) error {
+func (c *LocalModelNodeReconciler) launchPermissionFixJob(ctx context.Context, permissionFixImage string, owner *v1alpha1.LocalModelNode) error {
 	jobName := "fix-permissions-" + nodeName
 
 	existingJobs := &batchv1.JobList{}
@@ -248,14 +326,16 @@ func (c *LocalModelNodeReconciler) launchPermissionFixJob(ctx context.Context, m
 		{Name: "TARGET", Value: MountPath},
 	}
 
-	// Script is a Go constant, never interpolated with user data.
-	// SECURITY: double-quoting on variable expansions is critical —
-	// it prevents word splitting and shell injection. Do not remove the quotes.
-	script := `set -eu; chown -R "$FIX_UID:$FIX_GID" "$TARGET" && chcon -R -t container_file_t "$TARGET"`
-	if mcsLevel != "" {
-		env = append(env, corev1.EnvVar{Name: "MCS_LEVEL", Value: mcsLevel})
-		script = `set -eu; chown -R "$FIX_UID:$FIX_GID" "$TARGET" && chcon -R -t container_file_t -l "$MCS_LEVEL" "$TARGET"`
-	}
+	// The cache tree is relabeled recursively to the shared, category-less MCS level so it is
+	// readable from any consuming namespace's MCS context (see sharedMCSLevel). The whole
+	// MountPath is relabeled — MCS enforces "search" on parent directories, so a partial relabel
+	// would leave an un-traversable categorized parent and reintroduce the read denial.
+	//
+	// The level is the sharedMCSLevel Go constant ("s0"), never interpolated with user data, so it
+	// is safe to embed directly in the script. FIX_UID/FIX_GID/TARGET are passed via env.
+	// SECURITY: double-quoting on variable expansions is critical — it prevents word splitting and
+	// shell injection. Do not remove the quotes.
+	script := `set -eu; chown -R "$FIX_UID:$FIX_GID" "$TARGET" && chcon -R -t container_file_t -l ` + sharedMCSLevel + ` "$TARGET"`
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -274,8 +354,11 @@ func (c *LocalModelNodeReconciler) launchPermissionFixJob(ctx context.Context, m
 					RestartPolicy:      corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
 						SELinuxOptions: &corev1.SELinuxOptions{
-							Type:  "spc_t",
-							Level: mcsLevel,
+							Type: "spc_t",
+							// spc_t bypasses MCS, so this level does not gate the relabel; it is set
+							// to the shared level for determinism/hygiene now that the namespace MCS
+							// no longer feeds this path.
+							Level: sharedMCSLevel,
 						},
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,

--- a/pkg/controller/v1alpha1/localmodelnode/platform_odh_test.go
+++ b/pkg/controller/v1alpha1/localmodelnode/platform_odh_test.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -208,23 +209,6 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			// Simulate a root-owned volume that the agent can't write to, triggering the permission-fix job flow
 			isModelRootWritable = func() bool { return false }
 
-			// Patch the existing jobNamespace to add MCS annotation
-			existingNs := &corev1.Namespace{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelCacheNamespace}, existingNs)).Should(Succeed())
-			patch := client.MergeFrom(existingNs.DeepCopy())
-			if existingNs.Annotations == nil {
-				existingNs.Annotations = map[string]string{}
-			}
-			existingNs.Annotations["openshift.io/sa.scc.mcs"] = "s0:c28,c27"
-			Expect(k8sClient.Patch(ctx, existingNs, patch)).Should(Succeed())
-			defer func() {
-				ns := &corev1.Namespace{}
-				_ = k8sClient.Get(ctx, types.NamespacedName{Name: modelCacheNamespace}, ns)
-				p := client.MergeFrom(ns.DeepCopy())
-				delete(ns.Annotations, "openshift.io/sa.scc.mcs")
-				_ = k8sClient.Patch(ctx, ns, p)
-			}()
-
 			configMap := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      constants.InferenceServiceConfigMapName,
@@ -284,10 +268,10 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			Expect(container.Name).To(Equal("fix-permissions"))
 			Expect(container.Command).To(Equal([]string{
 				"sh", "-c",
-				`set -eu; chown -R "$FIX_UID:$FIX_GID" "$TARGET" && chcon -R -t container_file_t -l "$MCS_LEVEL" "$TARGET"`,
-			}))
+				`set -eu; chown -R "$FIX_UID:$FIX_GID" "$TARGET" && chcon -R -t container_file_t -l s0 "$TARGET"`,
+			}), "Relabel must target the shared category-less MCS level (s0), not a namespace MCS")
 
-			// Verify env vars
+			// Verify env vars — MCS_LEVEL is no longer passed; the shared level is a constant in the script
 			envMap := map[string]string{}
 			for _, e := range container.Env {
 				envMap[e.Name] = e.Value
@@ -295,7 +279,13 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			Expect(envMap).To(HaveKeyWithValue("FIX_UID", "1000"))
 			Expect(envMap).To(HaveKeyWithValue("FIX_GID", "1000"))
 			Expect(envMap).To(HaveKeyWithValue("TARGET", MountPath))
-			Expect(envMap).To(HaveKeyWithValue("MCS_LEVEL", "s0:c28,c27"))
+			Expect(envMap).NotTo(HaveKey("MCS_LEVEL"),
+				"MCS_LEVEL env must not be set — the relabel level is the shared s0 constant")
+
+			// Verify the permfix pod itself runs at the shared level
+			Expect(job.Spec.Template.Spec.SecurityContext.SELinuxOptions).NotTo(BeNil())
+			Expect(job.Spec.Template.Spec.SecurityContext.SELinuxOptions.Level).To(Equal("s0"))
+			Expect(job.Spec.Template.Spec.SecurityContext.SELinuxOptions.Type).To(Equal("spc_t"))
 
 			// Verify resource limits
 			Expect(container.Resources.Requests).NotTo(BeEmpty())
@@ -553,17 +543,20 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			isModelRootWritable = func() bool { return true }
 		})
 
-		It("Should reject invalid MCS level from namespace annotation", func() {
+		It("Should reject invalid MCS level from namespace annotation via the download job", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			DeferCleanup(cancel)
-
-			fsMock = &mockFileSystem{
-				subDirs: []os.DirEntry{},
-			}
+			fsMock.clear()
+			isModelRootWritable = func() bool { return true }
 			fsHelper = fsMock
-			isModelRootWritable = func() bool { return false }
+			storageKey := v1alpha1.GetStorageKey(sourceModelUri)
+			fsMock.mockModel(&MockFileInfo{name: storageKey, isDir: true})
 
-			// Patch namespace with an invalid MCS level (injection attempt)
+			// Patch jobNamespace with an invalid MCS level (injection attempt). enhanceDownloadJob
+			// resolves the download pod's MCS from this annotation (SCC MustRunAs admission) and
+			// must reject a malformed value rather than let it reach a shell argument. With the
+			// shared-label fix, resolveMCSLevel no longer runs on the permission-fix path, so this
+			// rejection guard now lives only on the download path.
 			existingNs := &corev1.Namespace{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: modelCacheNamespace}, existingNs)).Should(Succeed())
 			patch := client.MergeFrom(existingNs.DeepCopy())
@@ -590,7 +583,98 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(ctx, configMap)
 
+			clusterStorageContainer := &v1alpha1.ClusterStorageContainer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ocp-invalid-mcs"},
+				Spec:       clusterStorageContainerSpec,
+			}
+			Expect(k8sClient.Create(ctx, clusterStorageContainer)).Should(Succeed())
+			defer k8sClient.Delete(ctx, clusterStorageContainer)
+
+			nodeGroup := &v1alpha1.LocalModelNodeGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec:       localModelNodeGroupSpec,
+			}
+			Expect(k8sClient.Create(ctx, nodeGroup)).Should(Succeed())
+			defer k8sClient.Delete(ctx, nodeGroup)
+
 			nodeName = "worker-invalid-mcs"
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"node.kubernetes.io/instance-type": "gpu"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			defer k8sClient.Delete(ctx, node)
+
+			localModelNode := &v1alpha1.LocalModelNode{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: v1alpha1.LocalModelNodeSpec{
+					LocalModels: []v1alpha1.LocalModelInfo{
+						{SourceModelUri: sourceModelUri, ModelName: modelName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, localModelNode)).Should(Succeed())
+			defer k8sClient.Delete(ctx, localModelNode)
+
+			// enhanceDownloadJob rejects the invalid MCS before the job is created (controller.go
+			// calls it prior to Jobs.Create), so no download job is ever persisted.
+			downloadJobs := &batchv1.JobList{}
+			labelSelector := map[string]string{
+				"model": modelName,
+				"node":  nodeName,
+			}
+			Consistently(func() int {
+				_ = k8sClient.List(ctx, downloadJobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(labelSelector))
+				return len(downloadJobs.Items)
+			}, time.Second*3, interval).Should(Equal(0),
+				"No download job should be created when the namespace MCS annotation is invalid")
+
+			isModelRootWritable = func() bool { return true }
+		})
+
+		It("Should launch permission fix job when a subdirectory carries non-shared MCS categories", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			fsMock = &mockFileSystem{
+				subDirs: []os.DirEntry{},
+			}
+			fsHelper = fsMock
+			isModelRootWritable = func() bool { return true }
+
+			// Real temp dir with a readable subdirectory (mode 0750) so the permission scan passes
+			// the os.ReadDir check and reaches the MCS-label gate.
+			tmpDir, err := os.MkdirTemp("", "modelcache-mcs-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+			Expect(os.Mkdir(filepath.Join(tmpDir, "model-categorized"), 0o750)).To(Succeed())
+			savedModelsRoot := modelsRootFolder
+			modelsRootFolder = tmpDir
+			defer func() { modelsRootFolder = savedModelsRoot }()
+
+			// Inject a categorized-label result without needing a real SELinux filesystem.
+			savedMCS := folderHasNonSharedMCS
+			folderHasNonSharedMCS = func(string) (bool, error) { return true, nil }
+			defer func() { folderHasNonSharedMCS = savedMCS }()
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			nodeName = "worker-mcs-categorized"
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   nodeName,
@@ -614,20 +698,177 @@ var _ = Describe("LocalModelNode OCP platform hooks", func() {
 			Expect(k8sClient.Create(ctx, localModelNode)).Should(Succeed())
 			defer k8sClient.Delete(ctx, localModelNode)
 
-			// The reconciler should error due to invalid MCS, no fix job should be created
-			fixJobs := &batchv1.JobList{}
+			jobs := &batchv1.JobList{}
 			fixLabels := map[string]string{
 				"fix-permissions": "true",
 				"node":            nodeName,
 			}
-			// Wait a bit and ensure NO permission fix job is created
-			Consistently(func() int {
-				_ = k8sClient.List(ctx, fixJobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(fixLabels))
-				return len(fixJobs.Items)
-			}, time.Second*3, interval).Should(Equal(0),
-				"No permission fix job should be created with invalid MCS level")
+			Eventually(func() bool {
+				err := k8sClient.List(ctx, jobs, client.InNamespace(modelCacheNamespace), client.MatchingLabels(fixLabels))
+				return err == nil && len(jobs.Items) == 1
+			}, timeout, interval).Should(BeTrue(),
+				"Permission fix job should be created when a subdirectory carries MCS categories")
 
 			isModelRootWritable = func() bool { return true }
+		})
+
+		It("Should not launch permission fix job when subdirectories are at the shared MCS level", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			fsMock.clear()
+			fsHelper = fsMock
+			isModelRootWritable = func() bool { return true }
+			storageKey := v1alpha1.GetStorageKey(sourceModelUri)
+			fsMock.mockModel(&MockFileInfo{name: storageKey, isDir: true})
+
+			tmpDir, err := os.MkdirTemp("", "modelcache-mcs-shared-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(tmpDir)
+			Expect(os.Mkdir(filepath.Join(tmpDir, "model-shared"), 0o750)).To(Succeed())
+			savedModelsRoot := modelsRootFolder
+			modelsRootFolder = tmpDir
+			defer func() { modelsRootFolder = savedModelsRoot }()
+
+			// Folder already at the shared level → no relabel needed.
+			savedMCS := folderHasNonSharedMCS
+			folderHasNonSharedMCS = func(string) (bool, error) { return false, nil }
+			defer func() { folderHasNonSharedMCS = savedMCS }()
+
+			configMap := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KServeNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			clusterStorageContainer := &v1alpha1.ClusterStorageContainer{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-ocp-mcs-shared"},
+				Spec:       clusterStorageContainerSpec,
+			}
+			Expect(k8sClient.Create(ctx, clusterStorageContainer)).Should(Succeed())
+			defer k8sClient.Delete(ctx, clusterStorageContainer)
+
+			nodeGroup := &v1alpha1.LocalModelNodeGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "gpu"},
+				Spec:       localModelNodeGroupSpec,
+			}
+			Expect(k8sClient.Create(ctx, nodeGroup)).Should(Succeed())
+			defer k8sClient.Delete(ctx, nodeGroup)
+
+			nodeName = "worker-mcs-shared"
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   nodeName,
+					Labels: map[string]string{"node.kubernetes.io/instance-type": "gpu"},
+				},
+				Status: corev1.NodeStatus{
+					Conditions: []corev1.NodeCondition{
+						{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+			defer k8sClient.Delete(ctx, node)
+
+			localModelNode := &v1alpha1.LocalModelNode{
+				ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+				Spec: v1alpha1.LocalModelNodeSpec{
+					LocalModels: []v1alpha1.LocalModelInfo{
+						{SourceModelUri: sourceModelUri, ModelName: modelName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, localModelNode)).Should(Succeed())
+			defer k8sClient.Delete(ctx, localModelNode)
+
+			// Reconcile ran (download job appears), but no permission-fix job is created.
+			downloadJobs := &batchv1.JobList{}
+			Eventually(func() bool {
+				err := k8sClient.List(ctx, downloadJobs, client.InNamespace(modelCacheNamespace),
+					client.MatchingLabels(map[string]string{"model": modelName, "node": nodeName}))
+				return err == nil && len(downloadJobs.Items) == 1
+			}, timeout, interval).Should(BeTrue(), "Download job should be created")
+
+			fixJobs := &batchv1.JobList{}
+			fixErr := k8sClient.List(ctx, fixJobs, client.InNamespace(modelCacheNamespace),
+				client.MatchingLabels(map[string]string{"fix-permissions": "true", "node": nodeName}))
+			Expect(fixErr).ShouldNot(HaveOccurred())
+			Expect(fixJobs.Items).To(BeEmpty(),
+				"No permission fix job when subdirectories are already at the shared MCS level")
+		})
+	})
+
+	Context("parseMCSLevel", func() {
+		DescribeTable("extracts the MCS level from a full SELinux context",
+			func(selinuxContext, expected string) {
+				Expect(parseMCSLevel(selinuxContext)).To(Equal(expected))
+			},
+			// SplitN(":", 4) keeps the level (which itself contains a colon) intact.
+			Entry("context with categories", "system_u:object_r:container_file_t:s0:c2,c28", "s0:c2,c28"),
+			Entry("trailing null and newline trimmed", "system_u:object_r:container_file_t:s0:c2,c28\x00\n", "s0:c2,c28"),
+			Entry("category-less context", "system_u:object_r:container_file_t:s0", "s0"),
+			Entry("sensitivity range, no categories", "system_u:object_r:container_file_t:s0-s0", "s0-s0"),
+			Entry("too few segments", "s0:c2,c28", ""),
+			Entry("empty string", "", ""),
+		)
+
+		// folderHasNonSharedMCS treats a level as "categorized" when it still contains a colon.
+		DescribeTable("categorized predicate (parsed level contains a colon)",
+			func(selinuxContext string, hasCategories bool) {
+				Expect(strings.Contains(parseMCSLevel(selinuxContext), ":")).To(Equal(hasCategories))
+			},
+			Entry("categorized level", "system_u:object_r:container_file_t:s0:c2,c28", true),
+			Entry("shared level", "system_u:object_r:container_file_t:s0", false),
+			Entry("range without categories", "system_u:object_r:container_file_t:s0-s0", false),
+			Entry("unparseable context", "", false),
+		)
+	})
+
+	Context("relabel attempt cap", func() {
+		It("counts per path, enforces the cap, and resets when the folder is clean", func() {
+			path := "/var/lib/kserve/models/attempt-cap-test"
+			resetRelabelAttempts(path)
+			defer resetRelabelAttempts(path)
+
+			Expect(relabelAttemptCount(path)).To(Equal(0))
+
+			// Simulate a folder that never reaches the shared level: each reconcile records an
+			// attempt until the cap is reached.
+			for i := 1; i <= maxRelabelAttempts; i++ {
+				recordRelabelAttempt(path)
+				Expect(relabelAttemptCount(path)).To(Equal(i))
+			}
+			Expect(relabelAttemptCount(path)).To(BeNumerically(">=", maxRelabelAttempts),
+				"once at the cap the reconciler stops launching the privileged relabel job")
+
+			// A folder that reaches the shared level clears its counter, so a later legitimate
+			// re-download can be relabeled again.
+			resetRelabelAttempts(path)
+			Expect(relabelAttemptCount(path)).To(Equal(0))
+		})
+
+		It("tracks attempts independently per path", func() {
+			a := "/var/lib/kserve/models/cap-a"
+			b := "/var/lib/kserve/models/cap-b"
+			resetRelabelAttempts(a)
+			resetRelabelAttempts(b)
+			defer resetRelabelAttempts(a)
+			defer resetRelabelAttempts(b)
+
+			recordRelabelAttempt(a)
+			recordRelabelAttempt(a)
+			recordRelabelAttempt(b)
+
+			Expect(relabelAttemptCount(a)).To(Equal(2))
+			Expect(relabelAttemptCount(b)).To(Equal(1))
+
+			resetRelabelAttempts(a)
+			Expect(relabelAttemptCount(a)).To(Equal(0))
+			Expect(relabelAttemptCount(b)).To(Equal(1), "resetting one path must not affect another")
 		})
 	})
 })


### PR DESCRIPTION
Backport of opendatahub-io/kserve#1838 to `rhoai-3.5`.

Cherry-pick of commit `f68394fa5` (clean, no conflicts, no codegen drift).

**What this PR does / why we need it**:

Serving a model through the KServe local model cache (`LocalModelNamespaceCache`) reaches `NodeDownloaded` but crash-loops the runtime on startup (ovms example):

```
[modelmanager][error] Couldn't list directories in path: /mnt/models
[serving][error] The provided base path is invalid or doesn't exists
```

**Root cause:** an SELinux MCS category mismatch. The ODH permission-fix job labels cached models with the **download/job namespace's** MCS categories (e.g. `s0:c2,c28`), but the model is served from a **different namespace** whose pod has different categories (e.g. `s0:c31,c0`). Because the cache lives on `hostPath` / `local-storage` PVs — which the kubelet does not relabel per-consumer — the serving pod is denied read: `{c2,c28} ⊄ {c31,c0}`.

This PR relabels the cache tree to the category-less **shared** level (`container_file_t:s0`) so every consuming namespace's MCS set dominates it, gated on the **actual on-disk label** so already-downloaded caches self-heal on upgrade.

Changes (all behind `//go:build distro`; no default-build, API, SCC, or webhook changes):

- `parseMCSLevel` helper — `SplitN(":", 4)` so the level's own colon-separated categories are preserved.
- `folderHasNonSharedMCS` gate — checks the model dir **and its immediate entries**; ERANGE-safe xattr read via a size query.
- Permission-fix job relabels to the shared `s0` level. `resolveMCSLevel` is kept only for download-pod admission (SCC `MustRunAs`).
- Dropped the vestigial `LocalModelConfig` argument from `ensureModelRootFolderExistsAndIsWritable`.
- Promoted `golang.org/x/sys` to a direct dependency.

**Which issue(s) this PR fixes**:

JIRA: https://issues.redhat.com/browse/RHOAIENG-79770

**Release note**:
```release-note
Fix KServe local model cache serving failure on OpenShift caused by an SELinux MCS category mismatch: cached models are now relabeled to a shared, category-less SELinux level so they are readable across namespaces.
```
