### PR TITLE
fix(kserve-module): add autogluon-image to modelControllerImageParamMap

### DIFF
--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -84,6 +84,7 @@ var modelControllerImageParamMap = map[string]string{
 	"vllm-cpu-x86-image-fast-1-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION",
 	"vllm-cpu-x86-image-fast-2-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE_UPSTREAM_VERSION",
 	"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
+	"autogluon-image":                              "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
 }
 
 var wvaImageParamMap = map[string]string{

--- a/kserve-module/pkg/kservemodule/images.go
+++ b/kserve-module/pkg/kservemodule/images.go
@@ -1,6 +1,5 @@
 package kservemodule
 
-
 var kserveImageParamMap = map[string]string{
 	"kserve-controller":                                "RELATED_IMAGE_ODH_KSERVE_CONTROLLER_IMAGE",
 	"llmisvc-controller":                               "RELATED_IMAGE_ODH_KSERVE_LLMISVC_CONTROLLER_IMAGE",
@@ -84,7 +83,7 @@ var modelControllerImageParamMap = map[string]string{
 	"vllm-cpu-x86-image-fast-1-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_1_IMAGE_UPSTREAM_VERSION",
 	"vllm-cpu-x86-image-fast-2-upstream-version":    "RELATED_IMAGE_RHAII_VLLM_CPU_FAST_2_IMAGE_UPSTREAM_VERSION",
 	"guardrails-detector-huggingface-runtime-image": "RELATED_IMAGE_ODH_GUARDRAILS_DETECTOR_HUGGINGFACE_RUNTIME_IMAGE",
-	"autogluon-image":                              "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
+	"autogluon-image":                               "RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE",
 }
 
 var wvaImageParamMap = map[string]string{


### PR DESCRIPTION
Cherry-pick of opendatahub-io/kserve#1855 to rhoai-3.5.

## Summary

- Adds `autogluon-image` → `RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE` to `modelControllerImageParamMap` in [kserve-module/pkg/kservemodule/images.go](kserve-module/pkg/kservemodule/images.go)
- Without this mapping, the operator ignores the `RELATED_IMAGE_` env var and leaves the default upstream image in params.env

## Test plan

- [ ] `TestModelControllerImageParamMap_AllValuesAreRelatedImage` passes
- [ ] `TestImageParamMaps_NoKeyOverlap` passes
- [ ] Bundle sets `RELATED_IMAGE_ODH_KSERVE_AUTOGLUON_SERVER_IMAGE` and autogluon-image in params.env is overwritten