### PR TITLE
[RHOAIENG-74814] CVE-2025-66471: pin urllib3>=2.6.0

### DIFF
--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
     # CVE-2026-48526 PyJWT authentication bypass via JWK accepted as HMAC secret
     # Pinning because it is a transitive dependency.
     "pyjwt>=2.13.0",
+    # CVE-2025-66471 urllib3 Streaming API improperly handles highly compressed data
+    # Pinning because it is a transitive dependency.
+    "urllib3>=2.6.0",
 ]
 name = "kserve-storage"
 version = "0.17.0"

--- a/python/storage/uv.lock
+++ b/python/storage/uv.lock
@@ -696,6 +696,7 @@ dependencies = [
     { name = "huggingface-hub", extra = ["hf-transfer"] },
     { name = "pyjwt" },
     { name = "requests" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
@@ -711,6 +712,7 @@ requires-dist = [
     { name = "huggingface-hub", extras = ["hf-transfer"], specifier = ">=0.32.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "requests", specifier = ">=2.32.2,<3.0.0" },
+    { name = "urllib3", specifier = ">=2.6.0" },
 ]
 
 [[package]]
@@ -1062,11 +1064,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.4.0"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8a/78/16493d9c386d8e60e442a35feac5e00f0913c0f4b7c217c11e8ec2ff53e0/urllib3-2.4.0.tar.gz", hash = "sha256:414bc6535b787febd7567804cc015fee39daab8ad86268f1310a9250697de466", size = 390672, upload-time = "2025-04-10T15:23:39.232Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/11/cc635220681e93a0183390e26485430ca2c7b5f9d33b15c74c2861cb8091/urllib3-2.4.0-py3-none-any.whl", hash = "sha256:4e16665048960a0900c702d4a66415956a584919c03361cac9f1df5c5dd7e813", size = 128680, upload-time = "2025-04-10T15:23:37.377Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CVE-2025-66471: urllib3 Streaming API improperly handles highly compressed data

**What this PR does / why we need it**:

Pins `urllib3>=2.6.0` in `python/storage` (transitive via `requests`) so the storage-initializer image on `rhoai-3.4` installs a fixed urllib3. Previously locked at 2.4.0 (&lt; 2.6.0). Pinning because it is a transitive dependency.

**Which issue(s) this PR fixes**:
Fixes [RHOAIENG-74814](https://redhat.atlassian.net/browse/RHOAIENG-74814)

**Feature/Issue validation/testing**:

- [x] Built storage-initializer from this branch (`make docker-build-storageInitializer`)
- [x] Build log / runtime show `urllib3==2.7.0`
- [x] `snyk container test ... --severity=CVE-2025-66471` — CVE not found

**Special notes for your reviewer**:

On `rhoai-3.4`, storage-initializer installs from `python/storage` via uv (not the kserve poetry path used on `odh/stable-2.x`).

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?
- [x] Have you linked the JIRA issue(s) to this PR?

**Release note**:
```release-note
NONE
```

Made with [Cursor](https://cursor.com)