### PR TITLE
fix(llmisvc): drop redundant /dev/shm volumeMount from kv-cache offloading sample

### DIFF
--- a/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
+++ b/docs/samples/llmisvc/kv-cache-offloading/llm-inference-service-kv-cache-offloading.yaml
@@ -19,9 +19,6 @@ spec:
           sizeLimit: 13Gi
     containers:
       - name: main
-        volumeMounts:
-          - name: dshm
-            mountPath: /dev/shm
         resources:
           limits:
             cpu: '8'


### PR DESCRIPTION
#  Notes
follow up comments: https://github.com/red-hat-data-services/kserve/pull/4486#discussion_r3722438723 for cleanup

cc @andresllh @pierDipi 