### PR TITLE
fix(CVE-2026-59885): bump pyasn1 to >= 0.6.4

### DIFF
--- a/python/aiffairness/poetry.lock
+++ b/python/aiffairness/poetry.lock
@@ -1332,7 +1332,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2259,13 +2259,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/artexplainer/poetry.lock
+++ b/python/artexplainer/poetry.lock
@@ -1118,7 +1118,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2161,13 +2161,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_model/poetry.lock
+++ b/python/custom_model/poetry.lock
@@ -1075,7 +1075,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2034,13 +2034,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_tokenizer/poetry.lock
+++ b/python/custom_tokenizer/poetry.lock
@@ -917,7 +917,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1670,13 +1670,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/custom_transformer/poetry.lock
+++ b/python/custom_transformer/poetry.lock
@@ -989,7 +989,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1944,13 +1944,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/huggingfaceserver/poetry.lock
+++ b/python/huggingfaceserver/poetry.lock
@@ -2397,7 +2397,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -3987,13 +3987,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/kserve/poetry.lock
+++ b/python/kserve/poetry.lock
@@ -4225,13 +4225,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -7077,4 +7077,4 @@ storage = ["azure-identity", "azure-storage-blob", "azure-storage-file-share", "
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "e2522a000a2097cb171e1f99f03d932e905733b7283363a7dffe3e565552b363"
+content-hash = "073bf416f167545715296c364c2d0cf731336359d2db781e64bca0578e898bba"

--- a/python/kserve/pyproject.toml
+++ b/python/kserve/pyproject.toml
@@ -68,9 +68,9 @@ aiohttp = ">=3.14.0,<4.0.0"
 # CVE-2026-32597 PyJWT accepts unknown `crit` header extensions (RFC 7515 §4.1.11 MUST violation)
 # Pinning because it is a transitive dependency.
 PyJWT = ">=2.12.0"
-# CVE-2026-30922 / CVE-2026-23490 pyasn1 Vulnerable to Denial of Service
+# CVE-2026-30922 / CVE-2026-23490 / CVE-2026-59885 pyasn1 Vulnerable to Denial of Service
 # Pinning because it is a transitive dependency.
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 
 # Storage dependencies. They can be opted into by apps.
 requests = { version = "^2.32.2", optional = true }

--- a/python/lgbserver/poetry.lock
+++ b/python/lgbserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2442,13 +2442,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/paddleserver/poetry.lock
+++ b/python/paddleserver/poetry.lock
@@ -1620,7 +1620,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2611,13 +2611,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/pmmlserver/poetry.lock
+++ b/python/pmmlserver/poetry.lock
@@ -1664,7 +1664,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2482,13 +2482,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/sklearnserver/poetry.lock
+++ b/python/sklearnserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2416,13 +2416,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/storage/poetry.lock
+++ b/python/storage/poetry.lock
@@ -826,13 +826,13 @@ files = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]
@@ -1069,4 +1069,4 @@ zstd = ["backports-zstd (>=1.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.10,<3.13"
-content-hash = "106b0cd132bc1b79f8723cea423381e710628429370e4939999cbd27782c9f8d"
+content-hash = "7516ee85058261ed992b7af334e0ab27e1d4ff2e7a4724a2c0d09dbae3b9ecc5"

--- a/python/storage/pyproject.toml
+++ b/python/storage/pyproject.toml
@@ -35,9 +35,9 @@ urllib3 = {version = ">=2.7.0,<3.0.0"}
 # CVE-2026-48526 PyJWT authentication bypass via JWK accepted as HMAC secret
 # Pinning because it is a transitive dependency.
 PyJWT = {version = ">=2.13.0"}
-# CVE-2026-30922 / CVE-2026-23490 pyasn1 Vulnerable to Denial of Service
+# CVE-2026-30922 / CVE-2026-23490 / CVE-2026-59885 pyasn1 Vulnerable to Denial of Service
 # Pinning because it is a transitive dependency.
-pyasn1 = {version = ">=0.6.3"}
+pyasn1 = {version = ">=0.6.4"}
 
 
 #[tool.poetry-version-plugin]

--- a/python/test_resources/graph/error_404_isvc/poetry.lock
+++ b/python/test_resources/graph/error_404_isvc/poetry.lock
@@ -906,7 +906,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1594,13 +1594,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/test_resources/graph/success_200_isvc/poetry.lock
+++ b/python/test_resources/graph/success_200_isvc/poetry.lock
@@ -906,7 +906,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -1594,13 +1594,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]

--- a/python/xgbserver/poetry.lock
+++ b/python/xgbserver/poetry.lock
@@ -1609,7 +1609,7 @@ pandas = "^2.2.0"
 prometheus-client = "^0.20.0"
 protobuf = "^5.27.1"
 psutil = "^5.9.6"
-pyasn1 = ">=0.6.3"
+pyasn1 = ">=0.6.4"
 pydantic = "^2.5.0"
 PyJWT = ">=2.12.0"
 python-dateutil = "^2.8.0"
@@ -2427,13 +2427,13 @@ test = ["enum34", "ipaddress", "mock", "pywin32", "wmi"]
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 description = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde"},
-    {file = "pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf"},
+    {file = "pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b"},
+    {file = "pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81"},
 ]
 
 [[package]]


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps `pyasn1` from `>= 0.6.3` to `>= 0.6.4` in `python/storage/pyproject.toml` and `python/kserve/pyproject.toml` to address CVE-2026-59885 (pyasn1 Denial of Service via crafted ASN.1 OBJECT IDENTIFIER).

**Which issue(s) this PR fixes**:
Ref: [RHOAIENG-78430](https://redhat.atlassian.net/browse/RHOAIENG-78430)

**Type of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Feature/Issue validation/testing**:
Dependency version bump only — no functional changes.

```release-note
NONE
```