### PR TITLE
[RHOAIENG-74633] CVE-2026-32283: bump go-toolset to 1.25

### DIFF
--- a/Dockerfiles/agent.Dockerfile.konflux
+++ b/Dockerfiles/agent.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the inference-agent binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.

--- a/Dockerfiles/controller.Dockerfile.konflux
+++ b/Dockerfiles/controller.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.

--- a/Dockerfiles/localmodel-agent.Dockerfile.konflux
+++ b/Dockerfiles/localmodel-agent.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 USER root
 

--- a/Dockerfiles/localmodel.Dockerfile.konflux
+++ b/Dockerfiles/localmodel.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 USER root
 

--- a/Dockerfiles/router.Dockerfile.konflux
+++ b/Dockerfiles/router.Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the inference-router binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.25 AS builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/kserve
 
-go 1.24.1
+go 1.25.9
 
 require (
 	cloud.google.com/go/storage v1.51.0

--- a/qpext/go.mod
+++ b/qpext/go.mod
@@ -1,6 +1,6 @@
 module github.com/kserve/kserve/qpext
 
-go 1.23.6
+go 1.25.9
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1


### PR DESCRIPTION
## Summary
- Bump `ubi9/go-toolset` from 1.24 to 1.25 in all Konflux Dockerfiles
- Addresses CVE-2026-32283 (Go crypto/tls DoS via multiple TLS 1.3 key update messages) for odh-kserve-router-rhel9 and related Go components on rhoai-2.25
- Matches the fix already merged to rhoai-3.3 via red-hat-data-services/kserve#4500

## JIRA
https://issues.redhat.com/browse/RHOAIENG-74633

## Test plan
- [x] `make router` builds cleanly in worktree
- [ ] Konflux pipeline build passes on rhoai-2.25
- [ ] Container scan confirms CVE-2026-32283 resolved in odh-kserve-router-rhel9 image