### PR TITLE
fix: support both full JWK and raw key formats in JWE decryption

### DIFF
--- a/python/storage/kserve_storage/confidential/jwe_decryptor.py
+++ b/python/storage/kserve_storage/confidential/jwe_decryptor.py
@@ -104,7 +104,20 @@ class JWEDecryptor:
         # memory.  For very large models this may be a concern; consider splitting
         # large files before encryption or increasing container memory limits.
         key_bytes = self._resolver.resolve_key(rid)
-        symmetric_key = jwk.JWK(kty="oct", k=jwk.base64url_encode(key_bytes))
+        try:
+            # the kubernetes secret likely returns a utf-8 encoded value.
+            # so try to decode utf-8.
+            key_str = key_bytes.decode("utf-8")
+            try:
+                # if kubernetes secret was created from the full encryption key file,
+                # the value should be the full json.
+                symmetric_key = jwk.JWK.from_json(key_str)
+            except (ValueError, jwk.InvalidJWKValue):
+                # Not a JWK object - treat as raw key value
+                symmetric_key = jwk.JWK(kty="oct", k=key_str)
+        except UnicodeDecodeError:
+            # if we fail to decode, then the key is likely raw-bytes and should be encoded.
+            symmetric_key = jwk.JWK(kty="oct", k=jwe.base64url_encode(key_bytes))
 
         jwe_token = jwe.JWE()
         jwe_token.deserialize(path.read_text())

--- a/python/storage/test/test_confidential.py
+++ b/python/storage/test/test_confidential.py
@@ -17,14 +17,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from jwcrypto import jwe, jwk
-
 from kserve_storage.confidential import (
     CDHSecretResolver,
     JWEDecryptor,
     SecretResolutionError,
     SecretResolver,
 )
-
 
 # --- Helpers ---
 
@@ -146,7 +144,8 @@ class TestJWEDecryptorRoundTrip:
         encrypted_file = tmp_path / "model.bin.jwe"
         encrypted_file.write_text(token)
 
-        resolver = StubSecretResolver(key_bytes)
+        kbs_key = jwk.base64url_encode(key_bytes).encode("utf-8")
+        resolver = StubSecretResolver(kbs_key)
         decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
         output = decryptor.decrypt_file(encrypted_file)
 
@@ -179,6 +178,57 @@ class TestJWEDecryptorRoundTrip:
         decryptor = JWEDecryptor(resolver)
         with pytest.raises(ValueError, match="No resource_id"):
             decryptor.decrypt_file(encrypted_file)
+
+    def test_decrypt_file_with_full_jwk_json(self, tmp_path):
+        """Test decryption when resolver returns a full JWK JSON object."""
+        plaintext = b"model weights data here"
+        key_bytes = os.urandom(32)
+        token = _encrypt_jwe(plaintext, key_bytes)
+
+        encrypted_file = tmp_path / "model.bin.jwe"
+        encrypted_file.write_text(token)
+
+        # Create a full JWK JSON object
+        full_jwk = jwk.JWK(kty="oct", k=jwk.base64url_encode(key_bytes))
+        jwk_json = full_jwk.export().encode("utf-8")
+
+        # Resolver returns the full JWK JSON as bytes
+        resolver = StubSecretResolver(jwk_json)
+        decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
+        output = decryptor.decrypt_file(encrypted_file)
+
+        assert output == tmp_path / "model.bin"
+        assert output.read_bytes() == plaintext
+        assert not encrypted_file.exists()
+
+    def test_decrypt_file_with_full_jwk_json_with_metadata(self, tmp_path):
+        """Test decryption when resolver returns a JWK with algorithm and key_ops."""
+        plaintext = b"model weights data here"
+        key_bytes = os.urandom(32)
+        token = _encrypt_jwe(plaintext, key_bytes)
+
+        encrypted_file = tmp_path / "model.bin.jwe"
+        encrypted_file.write_text(token)
+
+        # Create a JWK with additional metadata (as KBS might store it)
+        import json
+
+        jwk_dict = {
+            "alg": "A256GCM",
+            "k": jwk.base64url_encode(key_bytes),
+            "key_ops": ["encrypt", "decrypt"],
+            "kty": "oct",
+        }
+        jwk_json = json.dumps(jwk_dict).encode("utf-8")
+
+        # Resolver returns the full JWK JSON as bytes
+        resolver = StubSecretResolver(jwk_json)
+        decryptor = JWEDecryptor(resolver, resource_id="kbs:///repo/type/tag")
+        output = decryptor.decrypt_file(encrypted_file)
+
+        assert output == tmp_path / "model.bin"
+        assert output.read_bytes() == plaintext
+        assert not encrypted_file.exists()
 
 
 class TestJWEDecryptorDirectory:


### PR DESCRIPTION
The KBS secret resolver can return either:
1. A full JWK JSON object with metadata (alg, key_ops, etc.)
2. A raw base64url-encoded symmetric key value

Previously, the code assumed all keys needed base64url encoding, which caused "Expected key of length 256, got 344" errors when the key was already properly formatted.

Now we:
- Decode the bytes response to a UTF-8 string
- Try parsing as a full JWK JSON object first
- Fall back to treating it as a raw key value if JSON parsing fails

This allows users to store either format in KBS without errors.

Assisted-by: Claude Code (claude.ai/code)

