### PR TITLE
fix(kserve-module): sync WVA openshift manifests with controller repo

### DIFF
--- a/kserve-module/prefetched-manifests-rhoai/wva/components/openshift/kustomization.yaml
+++ b/kserve-module/prefetched-manifests-rhoai/wva/components/openshift/kustomization.yaml
@@ -78,12 +78,12 @@ patches:
       value: false
     - op: add
       path: /spec/endpoints/0/tlsConfig/serverName
-      value: wva-controller-manager-metrics-service.wva-system.svc
+      value: workload-variant-autoscaler-controller-manager-metrics-service.redhat-ods-applications.svc
     - op: add
       path: /spec/endpoints/0/tlsConfig/ca
       value:
         configMap:
-          name: wva-metrics-server-ca
+          name: workload-variant-autoscaler-metrics-server-ca
           key: service-ca.crt
   target:
     kind: ServiceMonitor


### PR DESCRIPTION
## Summary
- Syncs `kserve-module/prefetched-manifests-rhoai/wva/components/openshift/kustomization.yaml` with the latest `workload-variant-autoscaler` controller manifests on `rhoai-3.5`
- Updates ServiceMonitor TLS `serverName` and metrics CA ConfigMap name to match workload-variant-autoscaler#219

This fixes the `odh-workload-variant-autoscaler-controller` manifest validation failure in the modular operators manifest validator (rhods-devops-infra).

## Root cause
WVA PR #219 (`fix: name of configmap used for TLS`) updated the OpenShift overlay to use the full service/ConfigMap names for the `redhat-ods-applications` namespace, but the prefetched manifests in the kserve module operator were not re-synced.

## Test plan
- [ ] Verify `diff -r` between `workload-variant-autoscaler/config` and `kserve-module/prefetched-manifests-rhoai/wva` is clean
- [ ] Re-run modular operators manifest validator for `odh-kserve-module-operator` image